### PR TITLE
Upload the Status Report Video to Cloudflare

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -1,8 +1,10 @@
 # standup Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-03-22
+Auto-generated from all feature plans. Last updated: 2026-03-23
 
 ## Active Technologies
+- C# / .NET 10.0 + Azure Functions Worker v4, Azure.Storage.Blobs 12.23.0, Azure.Identity 1.13.2, Microsoft.Azure.Functions.Worker.Extensions.EventGrid 3.6.0, HttpClient (Cloudflare Stream API) (003-stream-video-transcoding)
+- Azure Blob Storage (video files in `status-videos` container) (003-stream-video-transcoding)
 
 - Swift 6 (iOS client), C# / .NET 10 (Azure Functions), Bicep (infrastructure) + SwiftUI, URLSession, Azure.Storage.Blobs SDK, Azure Functions runtime v4, Azure API Management (002-video-upload-processing)
 
@@ -22,6 +24,7 @@ tests/
 Swift 6 (iOS client), C# / .NET 10 (Azure Functions), Bicep (infrastructure): Follow standard conventions
 
 ## Recent Changes
+- 003-stream-video-transcoding: Added C# / .NET 10.0 + Azure Functions Worker v4, Azure.Storage.Blobs 12.23.0, Azure.Identity 1.13.2, Microsoft.Azure.Functions.Worker.Extensions.EventGrid 3.6.0, HttpClient (Cloudflare Stream API)
 
 - 002-video-upload-processing: Added Swift 6 (iOS client), C# / .NET 10 (Azure Functions), Bicep (infrastructure) + SwiftUI, URLSession, Azure.Storage.Blobs SDK, Azure Functions runtime v4, Azure API Management
 

--- a/Apple/Projects/Standup/Resources/Localizable.xcstrings
+++ b/Apple/Projects/Standup/Resources/Localizable.xcstrings
@@ -7,31 +7,10 @@
     "%@%%" : {
 
     },
-    "%lld" : {
-
-    },
     "Camera & Microphone Access Required" : {
 
     },
-    "Cancel" : {
-
-    },
-    "Cancel Upload" : {
-
-    },
-    "Cancel Upload?" : {
-
-    },
     "Cancelled" : {
-
-    },
-    "Discard" : {
-
-    },
-    "Discard Recording?" : {
-
-    },
-    "Discards this recording and returns to the camera" : {
 
     },
     "main_scene_title" : {
@@ -45,34 +24,7 @@
         }
       }
     },
-    "Open Settings" : {
-
-    },
-    "Opens the Settings app where you can grant camera and microphone access" : {
-
-    },
-    "Re-record" : {
-
-    },
-    "Record Status Update" : {
-
-    },
-    "Record Update" : {
-
-    },
-    "Recording error: %@" : {
-
-    },
-    "Records a 30-second status video update" : {
-
-    },
-    "Retry" : {
-
-    },
     "Retry %@ of 3" : {
-
-    },
-    "Review" : {
 
     },
     "Standup" : {
@@ -85,18 +37,6 @@
           }
         }
       }
-    },
-    "Start recording" : {
-
-    },
-    "Stop recording" : {
-
-    },
-    "Stops recording and shows the video for review" : {
-
-    },
-    "Submit" : {
-
     },
     "The video will not be uploaded." : {
 

--- a/api/Api.Tests/Functions/ProcessVideoTests.cs
+++ b/api/Api.Tests/Functions/ProcessVideoTests.cs
@@ -1,0 +1,429 @@
+// Copyright 2026 Michael F. Collins, III
+// Licensed under the Naked Standup Source-Available Temporary License
+// See LICENSE.md for license terms.
+
+using Azure.Messaging.EventGrid;
+using Azure.Messaging.EventGrid.SystemEvents;
+using Api.Functions;
+using Api.Models;
+using Api.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Functions;
+
+public sealed class ProcessVideoTests
+{
+    private static readonly Uri FakeReadSasUri = new(
+        "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4?sv=2025-01-05&se=...&sp=r&spr=https&sig=...");
+
+    private readonly Mock<ILogger<ProcessVideo>> _mockLogger;
+    private readonly Mock<ISasUrlService> _mockSasService;
+    private readonly Mock<ICloudflareStreamService> _mockCloudflareService;
+    private readonly ProcessVideo _function;
+
+    public ProcessVideoTests()
+    {
+        _mockLogger = new Mock<ILogger<ProcessVideo>>();
+        _mockSasService = new Mock<ISasUrlService>();
+        _mockCloudflareService = new Mock<ICloudflareStreamService>();
+        _function = new ProcessVideo(
+            _mockLogger.Object,
+            _mockSasService.Object,
+            _mockCloudflareService.Object);
+    }
+
+    private static EventGridEvent CreateBlobCreatedEvent(
+        string blobUrl,
+        string contentType,
+        long contentLength,
+        string eTag = "\"abc123\"")
+    {
+        var json = $$"""
+            {
+                "url": "{{blobUrl}}",
+                "contentType": "{{contentType}}",
+                "contentLength": {{contentLength}},
+                "eTag": {{eTag}},
+                "api": "PutBlob",
+                "blobType": "BlockBlob"
+            }
+            """;
+        return new EventGridEvent(
+            "/blobServices/default/containers/status-videos/blobs/uploads/test.mp4",
+            "Microsoft.Storage.BlobCreated",
+            "0.0",
+            BinaryData.FromString(json));
+    }
+
+    private static CloudflareStreamResponse CreateSuccessResponse(string uid = "test-uid-123") =>
+        new CloudflareStreamResponse(
+            Success: true,
+            Result: new CloudflareStreamResult(
+                Uid: uid,
+                ReadyToStream: false,
+                Status: new CloudflareStreamStatus(State: "queued", null, null, null),
+                Playback: null),
+            Errors: [],
+            Messages: []);
+
+    [Fact]
+    public async Task RunAsync_ValidMp4Blob_GeneratesReadSasUrlAndSubmitsToCloudflare()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSuccessResponse());
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        await _function.RunAsync(evt);
+
+        _mockSasService.Verify(
+            s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidQuicktimeBlob_ProcessesNormally()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSuccessResponse());
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mov",
+            "video/quicktime",
+            3_000_000);
+
+        await _function.RunAsync(evt);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_UnsupportedContentType_DoesNotSubmitToCloudflare()
+    {
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.txt",
+            "text/plain",
+            1_000);
+
+        await _function.RunAsync(evt);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_ZeroSizeBlob_DoesNotSubmitToCloudflare()
+    {
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            0);
+
+        await _function.RunAsync(evt);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_OversizedBlob_DoesNotSubmitToCloudflare()
+    {
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            52_428_801);
+
+        await _function.RunAsync(evt);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_BlobNotInUploadsPath_DoesNotSubmitToCloudflare()
+    {
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/other/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        await _function.RunAsync(evt);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_DuplicateETag_DoesNotSubmitToCloudflareSecondTime()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSuccessResponse());
+
+        var evt1 = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000,
+            "\"duplicate-etag\"");
+        var evt2 = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000,
+            "\"duplicate-etag\"");
+
+        await _function.RunAsync(evt1);
+        await _function.RunAsync(evt2);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidBlob_CallsGenerateReadSasUrlWithCorrectBlobPath()
+    {
+        var blobPath = "uploads/test-video.mp4";
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSuccessResponse());
+
+        var evt = CreateBlobCreatedEvent(
+            $"https://mystorageaccount.blob.core.windows.net/status-videos/{blobPath}",
+            "video/mp4",
+            5_000_000);
+
+        await _function.RunAsync(evt);
+
+        _mockSasService.Verify(
+            s => s.GenerateReadSasUrlAsync(blobPath, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidBlob_CallsSubmitForTranscodingWithSasUrl()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSuccessResponse());
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        await _function.RunAsync(evt);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(FakeReadSasUri, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_CloudflareServiceThrows_ExceptionPropagates()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Service unavailable", null, System.Net.HttpStatusCode.ServiceUnavailable));
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => _function.RunAsync(evt));
+    }
+
+    [Fact]
+    public async Task RunAsync_PermanentCloudflareFailure_DoesNotThrow()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new CloudflareStreamPermanentException("Bad request from Cloudflare"));
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        // Should not throw — permanent failures are acknowledged (no retry)
+        await _function.RunAsync(evt);
+    }
+
+    // --- T017: Failure and retry behavior tests ---
+
+    [Fact]
+    public async Task RunAsync_Cloudflare503_ExceptionPropagates()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Service unavailable", null, System.Net.HttpStatusCode.ServiceUnavailable));
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => _function.RunAsync(evt));
+    }
+
+    [Fact]
+    public async Task RunAsync_Cloudflare429_ExceptionPropagates()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Too many requests", null, System.Net.HttpStatusCode.TooManyRequests));
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => _function.RunAsync(evt));
+    }
+
+    [Fact]
+    public async Task RunAsync_CloudflareTimeout_TaskCanceledExceptionPropagates()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+        _mockCloudflareService
+            .Setup(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("Request timed out"));
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() => _function.RunAsync(evt));
+    }
+
+    [Fact]
+    public async Task RunAsync_SasUrlGenerationFails_ExceptionPropagates()
+    {
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Storage service unavailable"));
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _function.RunAsync(evt));
+    }
+
+    [Fact]
+    public async Task RunAsync_PermanentCloudflareFailure_AllowsRetryOfSameETag()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+
+        _mockCloudflareService
+            .SetupSequence(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new CloudflareStreamPermanentException("Bad request"))
+            .ReturnsAsync(CreateSuccessResponse());
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000,
+            "\"retry-permanent-etag\"");
+
+        // First call — permanent failure acknowledged, eTag removed from cache
+        await _function.RunAsync(evt);
+
+        // Second call with same eTag — should re-process since eTag was cleared
+        await _function.RunAsync(evt);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task RunAsync_TransientFailure_AllowsRetryOfSameETag()
+    {
+        var sasResult = new SasUrlResult(FakeReadSasUri, DateTimeOffset.UtcNow.AddMinutes(60));
+        _mockSasService
+            .Setup(s => s.GenerateReadSasUrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sasResult);
+
+        _mockCloudflareService
+            .SetupSequence(s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Service unavailable", null, System.Net.HttpStatusCode.ServiceUnavailable))
+            .ReturnsAsync(CreateSuccessResponse());
+
+        var evt = CreateBlobCreatedEvent(
+            "https://mystorageaccount.blob.core.windows.net/status-videos/uploads/test.mp4",
+            "video/mp4",
+            5_000_000,
+            "\"retry-transient-etag\"");
+
+        // First call — transient failure throws, eTag removed from cache
+        await Assert.ThrowsAsync<HttpRequestException>(() => _function.RunAsync(evt));
+
+        // Second call with same eTag — should re-process since eTag was cleared after exception
+        await _function.RunAsync(evt);
+
+        _mockCloudflareService.Verify(
+            s => s.SubmitForTranscodingAsync(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+}

--- a/api/Api.csproj
+++ b/api/Api.csproj
@@ -20,5 +20,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.6.0" />
   </ItemGroup>
 </Project>

--- a/api/Functions/ProcessVideo.cs
+++ b/api/Functions/ProcessVideo.cs
@@ -1,0 +1,120 @@
+// Copyright 2026 Michael F. Collins, III
+// Licensed under the Naked Standup Source-Available Temporary License
+// See LICENSE.md for license terms.
+
+using System.Collections.Concurrent;
+using Azure.Messaging.EventGrid;
+using Azure.Messaging.EventGrid.SystemEvents;
+using Azure.Storage.Blobs;
+using Api.Models;
+using Api.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Functions;
+
+public sealed class ProcessVideo(
+    ILogger<ProcessVideo> logger,
+    ISasUrlService sasUrlService,
+    ICloudflareStreamService cloudflareStreamService)
+{
+    private const long MaxBlobSizeBytes = 52_428_800; // 50 MB
+    private static readonly string[] SupportedContentTypes = ["video/mp4", "video/quicktime"];
+
+    private readonly ConcurrentDictionary<string, bool> _processedETags = new();
+
+    [Function(nameof(ProcessVideo))]
+    public async Task RunAsync(
+        [EventGridTrigger] EventGridEvent eventGridEvent,
+        CancellationToken cancellationToken = default)
+    {
+        var blobData = eventGridEvent.Data.ToObjectFromJson<StorageBlobCreatedEventData>();
+
+        var blobUri = new Uri(blobData!.Url);
+        var blobUriBuilder = new BlobUriBuilder(blobUri);
+        var blobPath = blobUriBuilder.BlobName;
+        var contentType = blobData.ContentType;
+        var contentLength = blobData.ContentLength;
+        var eTag = blobData.ETag;
+
+        logger.LogInformation(
+            "Video blob created event received. BlobPath={BlobPath}, "
+            + "ContentType={ContentType}, ContentLength={ContentLength}, ETag={ETag}",
+            blobPath, contentType, contentLength, eTag);
+
+        if (!blobPath.StartsWith("uploads/", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogInformation(
+                "Blob skipped: not in uploads/ path. BlobPath={BlobPath}, Reason={Reason}",
+                blobPath, "WrongPathPrefix");
+            return;
+        }
+
+        if (!SupportedContentTypes.Contains(contentType, StringComparer.OrdinalIgnoreCase))
+        {
+            logger.LogInformation(
+                "Blob skipped: unsupported content type. BlobPath={BlobPath}, "
+                + "ContentType={ContentType}, Reason={Reason}",
+                blobPath, contentType, "UnsupportedContentType");
+            return;
+        }
+
+        if (contentLength <= 0 || contentLength > MaxBlobSizeBytes)
+        {
+            logger.LogInformation(
+                "Blob skipped: content length out of range. BlobPath={BlobPath}, "
+                + "ContentLength={ContentLength}, Reason={Reason}",
+                blobPath, contentLength, "InvalidSize");
+            return;
+        }
+
+        if (!_processedETags.TryAdd(eTag, true))
+        {
+            logger.LogInformation(
+                "Blob skipped: duplicate event. BlobPath={BlobPath}, "
+                + "ETag={ETag}, Reason={Reason}",
+                blobPath, eTag, "DuplicateETag");
+            return;
+        }
+
+        // ETag was added; remove it if processing fails so Event Grid retries can succeed
+        try
+        {
+            var sasResult = await sasUrlService.GenerateReadSasUrlAsync(blobPath, cancellationToken);
+
+            logger.LogInformation(
+                "SAS URL generated for blob. BlobPath={BlobPath}, SasExpiry={SasExpiry}",
+                blobPath, sasResult.ExpiresAt);
+
+            CloudflareStreamResponse cfResponse;
+            try
+            {
+                cfResponse = await cloudflareStreamService.SubmitForTranscodingAsync(
+                    sasResult.SasUri, blobPath, cancellationToken);
+            }
+            catch (CloudflareStreamPermanentException ex)
+            {
+                // Permanent failure — acknowledge event, do not retry
+                _processedETags.TryRemove(eTag, out _);
+                logger.LogError(
+                    ex,
+                    "Permanent Cloudflare Stream error. BlobPath={BlobPath}, "
+                    + "ContentType={ContentType}, ContentLength={ContentLength}, "
+                    + "FailureClassification={FailureClassification}",
+                    blobPath, contentType, contentLength, "Permanent");
+                return;
+            }
+
+            logger.LogInformation(
+                "Video submitted for transcoding. BlobPath={BlobPath}, "
+                + "VideoUid={VideoUid}, State={State}",
+                blobPath, cfResponse.Result?.Uid, cfResponse.Result?.Status?.State);
+        }
+        catch
+        {
+            // Transient failure — remove eTag so a retry can re-process this event
+            _processedETags.TryRemove(eTag, out _);
+            throw;
+        }
+    }
+}

--- a/api/Models/CloudflareStreamRequest.cs
+++ b/api/Models/CloudflareStreamRequest.cs
@@ -1,0 +1,14 @@
+// Copyright 2026 Michael F. Collins, III
+// Licensed under the Naked Standup Source-Available Temporary License
+// See LICENSE.md for license terms.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Api.Models;
+
+public record CloudflareStreamRequest(
+    [property: JsonPropertyName("url")] string Url,
+    [property: JsonPropertyName("meta")] Dictionary<string, string>? Meta = null,
+    [property: JsonPropertyName("requireSignedURLs")] bool? RequireSignedURLs = null
+);

--- a/api/Models/CloudflareStreamResponse.cs
+++ b/api/Models/CloudflareStreamResponse.cs
@@ -1,0 +1,44 @@
+// Copyright 2026 Michael F. Collins, III
+// Licensed under the Naked Standup Source-Available Temporary License
+// See LICENSE.md for license terms.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Api.Models;
+
+public record CloudflareStreamResponse(
+    [property: JsonPropertyName("success")] bool Success,
+    [property: JsonPropertyName("result")] CloudflareStreamResult? Result,
+    [property: JsonPropertyName("errors")] List<CloudflareApiError> Errors,
+    [property: JsonPropertyName("messages")] List<CloudflareApiMessage> Messages
+);
+
+public record CloudflareStreamResult(
+    [property: JsonPropertyName("uid")] string Uid,
+    [property: JsonPropertyName("readyToStream")] bool ReadyToStream,
+    [property: JsonPropertyName("status")] CloudflareStreamStatus? Status,
+    [property: JsonPropertyName("playback")] CloudflarePlayback? Playback
+);
+
+public record CloudflareStreamStatus(
+    [property: JsonPropertyName("state")] string State,
+    [property: JsonPropertyName("pctComplete")] string? PctComplete,
+    [property: JsonPropertyName("errorReasonCode")] string? ErrorReasonCode,
+    [property: JsonPropertyName("errorReasonText")] string? ErrorReasonText
+);
+
+public record CloudflarePlayback(
+    [property: JsonPropertyName("hls")] string? Hls,
+    [property: JsonPropertyName("dash")] string? Dash
+);
+
+public record CloudflareApiError(
+    [property: JsonPropertyName("code")] int Code,
+    [property: JsonPropertyName("message")] string Message
+);
+
+public record CloudflareApiMessage(
+    [property: JsonPropertyName("code")] int Code,
+    [property: JsonPropertyName("message")] string Message
+);

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -22,6 +22,10 @@ var host = new HostBuilder()
             return new BlobServiceClient(new Uri(blobEndpoint), new DefaultAzureCredential());
         });
         services.AddSingleton<ISasUrlService, SasUrlService>();
+        services.AddHttpClient<ICloudflareStreamService, CloudflareStreamService>(client =>
+        {
+            client.BaseAddress = new Uri("https://api.cloudflare.com/client/v4/");
+        });
     })
     .Build();
 

--- a/api/Services/CloudflareStreamService.cs
+++ b/api/Services/CloudflareStreamService.cs
@@ -33,7 +33,7 @@ public sealed class CloudflareStreamService(
         httpRequest.Headers.Add("Authorization", $"Bearer {_apiToken}");
         httpRequest.Content = JsonContent.Create(request);
 
-        var response = await httpClient.SendAsync(httpRequest, cancellationToken);
+        using var response = await httpClient.SendAsync(httpRequest, cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests ||
             (int)response.StatusCode >= 500)
@@ -55,8 +55,11 @@ public sealed class CloudflareStreamService(
         response.EnsureSuccessStatusCode();
 
         var result = await response.Content.ReadFromJsonAsync<CloudflareStreamResponse>(
-            cancellationToken: cancellationToken);
-        return result!;
+            cancellationToken: cancellationToken)
+            ?? throw new InvalidOperationException(
+                "Cloudflare Stream returned a success response but the response body could not be deserialized.");
+
+        return result;
     }
 }
 

--- a/api/Services/CloudflareStreamService.cs
+++ b/api/Services/CloudflareStreamService.cs
@@ -1,0 +1,69 @@
+// Copyright 2026 Michael F. Collins, III
+// Licensed under the Naked Standup Source-Available Temporary License
+// See LICENSE.md for license terms.
+
+using System.Net;
+using System.Net.Http.Json;
+using Api.Models;
+using Microsoft.Extensions.Configuration;
+
+namespace Api.Services;
+
+public sealed class CloudflareStreamService(
+    HttpClient httpClient,
+    IConfiguration configuration) : ICloudflareStreamService
+{
+    private readonly string _accountId = configuration["CLOUDFLARE_ACCOUNT_ID"]
+        ?? throw new InvalidOperationException("CLOUDFLARE_ACCOUNT_ID is not configured.");
+    private readonly string _apiToken = configuration["CLOUDFLARE_API_TOKEN"]
+        ?? throw new InvalidOperationException("CLOUDFLARE_API_TOKEN is not configured.");
+
+    public async Task<CloudflareStreamResponse> SubmitForTranscodingAsync(
+        Uri videoReadUrl,
+        string blobPath,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new CloudflareStreamRequest(
+            Url: videoReadUrl.ToString(),
+            Meta: new Dictionary<string, string> { ["blobPath"] = blobPath });
+
+        using var httpRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"accounts/{_accountId}/stream/copy");
+        httpRequest.Headers.Add("Authorization", $"Bearer {_apiToken}");
+        httpRequest.Content = JsonContent.Create(request);
+
+        var response = await httpClient.SendAsync(httpRequest, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.TooManyRequests ||
+            (int)response.StatusCode >= 500)
+        {
+            throw new HttpRequestException(
+                $"Transient error from Cloudflare Stream: {(int)response.StatusCode}",
+                null,
+                response.StatusCode);
+        }
+
+        if (response.StatusCode == HttpStatusCode.BadRequest ||
+            response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new CloudflareStreamPermanentException(
+                $"Permanent error from Cloudflare Stream ({(int)response.StatusCode}): {errorBody}");
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<CloudflareStreamResponse>(
+            cancellationToken: cancellationToken);
+        return result!;
+    }
+}
+
+public sealed class CloudflareStreamPermanentException : Exception
+{
+    public CloudflareStreamPermanentException(string message) : base(message) { }
+
+    public CloudflareStreamPermanentException(string message, Exception inner)
+        : base(message, inner) { }
+}

--- a/api/Services/ICloudflareStreamService.cs
+++ b/api/Services/ICloudflareStreamService.cs
@@ -1,0 +1,15 @@
+// Copyright 2026 Michael F. Collins, III
+// Licensed under the Naked Standup Source-Available Temporary License
+// See LICENSE.md for license terms.
+
+using Api.Models;
+
+namespace Api.Services;
+
+public interface ICloudflareStreamService
+{
+    Task<CloudflareStreamResponse> SubmitForTranscodingAsync(
+        Uri videoReadUrl,
+        string blobPath,
+        CancellationToken cancellationToken = default);
+}

--- a/api/Services/ISasUrlService.cs
+++ b/api/Services/ISasUrlService.cs
@@ -11,4 +11,8 @@ public interface ISasUrlService
     Task<SasUrlResult> GenerateSasUrlAsync(
         string blobPath,
         CancellationToken cancellationToken = default);
+
+    Task<SasUrlResult> GenerateReadSasUrlAsync(
+        string blobPath,
+        CancellationToken cancellationToken = default);
 }

--- a/api/Services/SasUrlService.cs
+++ b/api/Services/SasUrlService.cs
@@ -43,4 +43,37 @@ public sealed class SasUrlService(BlobServiceClient blobServiceClient) : ISasUrl
 
         return new SasUrlResult(blobUriBuilder.ToUri(), expiresOn);
     }
+
+    public async Task<SasUrlResult> GenerateReadSasUrlAsync(
+        string blobPath,
+        CancellationToken cancellationToken = default)
+    {
+        var startsOn = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var expiresOn = DateTimeOffset.UtcNow.AddMinutes(60);
+
+        var userDelegationKey = await blobServiceClient.GetUserDelegationKeyAsync(
+            startsOn,
+            expiresOn,
+            cancellationToken);
+
+        var sasBuilder = new BlobSasBuilder
+        {
+            BlobContainerName = ContainerName,
+            BlobName = blobPath,
+            Resource = "b",
+            StartsOn = startsOn,
+            ExpiresOn = expiresOn,
+            Protocol = SasProtocol.Https
+        };
+        sasBuilder.SetPermissions(BlobSasPermissions.Read);
+
+        var blobUriBuilder = new BlobUriBuilder(blobServiceClient.Uri)
+        {
+            BlobContainerName = ContainerName,
+            BlobName = blobPath,
+            Sas = sasBuilder.ToSasQueryParameters(userDelegationKey, blobServiceClient.AccountName)
+        };
+
+        return new SasUrlResult(blobUriBuilder.ToUri(), expiresOn);
+    }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -19,6 +19,16 @@ param publisherEmail string = 'support@nakedstandup.app'
 @description('The publisher name for the API Management instance.')
 param publisherName string = 'Naked Standup'
 
+@description('Whether to enable Event Grid subscription for blob-created events. Set to false on first provision, true after the Function App is deployed.')
+param enableEventGrid bool = false
+
+@description('The Cloudflare API token used to authenticate requests to the Cloudflare Stream API.')
+@secure()
+param cloudflareApiToken string
+
+@description('The Cloudflare account ID used to identify the account when submitting videos to Cloudflare Stream.')
+param cloudflareAccountId string
+
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 
@@ -65,6 +75,7 @@ module functionApp './modules/function-app.bicep' = {
 		storageAccountName: storage.outputs.name
 		storageAccountBlobEndpoint: storage.outputs.primaryBlobEndpoint
 		appInsightsConnectionString: monitoring.outputs.connectionString
+		keyVaultName: '${abbrs.keyVault}-standup-${resourceToken}'
 	}
 }
 
@@ -78,6 +89,22 @@ module keyVault './modules/key-vault.bicep' = {
 		functionAppPrincipalId: functionApp.outputs.principalId
 		apimPrincipalId: apim.outputs.principalId
 		logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
+		cloudflareApiToken: cloudflareApiToken
+		cloudflareAccountId: cloudflareAccountId
+	}
+}
+
+module eventGrid './modules/event-grid.bicep' = {
+	name: 'event-grid'
+	scope: resourceGroup
+	params: {
+		storageAccountName: storage.outputs.name
+		storageAccountId: storage.outputs.id
+		location: location
+		tags: tags
+		functionAppHostName: functionApp.outputs.defaultHostName
+		functionAppId: functionApp.outputs.id
+		enableEventGrid: enableEventGrid
 	}
 }
 
@@ -128,7 +155,6 @@ output AZURE_RESOURCE_GROUP string = resourceGroup.name
 output AZURE_APPLICATION_INSIGHTS_NAME string = monitoring.outputs.name
 
 @description('The connection string of the Application Insights instance.')
-@secure()
 output AZURE_APPLICATION_INSIGHTS_CONNECTION_STRING string = monitoring.outputs.connectionString
 
 @description('The name of the Log Analytics Workspace.')

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -4,7 +4,10 @@
 
 using './main.bicep'
 
+param cloudflareAccountId = readEnvironmentVariable('CLOUDFLARE_ACCOUNT_ID')
+param cloudflareApiToken = readEnvironmentVariable('CLOUDFLARE_API_TOKEN')
 param environmentName = readEnvironmentVariable('AZURE_ENV_NAME')
 param location = readEnvironmentVariable('AZURE_LOCATION', 'eastus2')
 param publisherEmail = readEnvironmentVariable('AZURE_PUBLISHER_EMAIL', 'support@nakedstandup.app')
 param publisherName = readEnvironmentVariable('AZURE_PUBLISHER_NAME', 'Naked Standup')
+param enableEventGrid = true

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -10,4 +10,4 @@ param environmentName = readEnvironmentVariable('AZURE_ENV_NAME')
 param location = readEnvironmentVariable('AZURE_LOCATION', 'eastus2')
 param publisherEmail = readEnvironmentVariable('AZURE_PUBLISHER_EMAIL', 'support@nakedstandup.app')
 param publisherName = readEnvironmentVariable('AZURE_PUBLISHER_NAME', 'Naked Standup')
-param enableEventGrid = true
+param enableEventGrid = readEnvironmentVariable('ENABLE_EVENT_GRID', 'false') == 'true'

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "8560613244539196472"
+      "templateHash": "4263014713806253971"
     }
   },
   "parameters": {
@@ -36,6 +36,25 @@
       "defaultValue": "Naked Standup",
       "metadata": {
         "description": "The publisher name for the API Management instance."
+      }
+    },
+    "enableEventGrid": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Whether to enable Event Grid subscription for blob-created events. Set to false on first provision, true after the Function App is deployed."
+      }
+    },
+    "cloudflareApiToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The Cloudflare API token used to authenticate requests to the Cloudflare Stream API."
+      }
+    },
+    "cloudflareAccountId": {
+      "type": "string",
+      "metadata": {
+        "description": "The Cloudflare account ID used to identify the account when submitting videos to Cloudflare Stream."
       }
     }
   },
@@ -361,6 +380,9 @@
           },
           "appInsightsConnectionString": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'monitoring'), '2022-09-01').outputs.connectionString.value]"
+          },
+          "keyVaultName": {
+            "value": "[format('{0}-standup-{1}', variables('abbrs').keyVault, variables('resourceToken'))]"
           }
         },
         "template": {
@@ -370,7 +392,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.23.1.45101",
-              "templateHash": "11839856004085231617"
+              "templateHash": "5705499692470354204"
             }
           },
           "parameters": {
@@ -421,6 +443,12 @@
               "type": "string",
               "metadata": {
                 "description": "The connection string for the Application Insights instance."
+              }
+            },
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Key Vault containing Cloudflare credentials."
               }
             }
           },
@@ -483,6 +511,14 @@
                     {
                       "name": "AZURE_STORAGE_BLOB_ENDPOINT",
                       "value": "[parameters('storageAccountBlobEndpoint')]"
+                    },
+                    {
+                      "name": "CLOUDFLARE_ACCOUNT_ID",
+                      "value": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=CloudflareAccountId)', parameters('keyVaultName'))]"
+                    },
+                    {
+                      "name": "CLOUDFLARE_API_TOKEN",
+                      "value": "[format('@Microsoft.KeyVault(VaultName={0};SecretName=CloudflareApiToken)', parameters('keyVaultName'))]"
                     }
                   ]
                 },
@@ -624,6 +660,12 @@
           },
           "logAnalyticsWorkspaceId": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'monitoring'), '2022-09-01').outputs.logAnalyticsWorkspaceId.value]"
+          },
+          "cloudflareApiToken": {
+            "value": "[parameters('cloudflareApiToken')]"
+          },
+          "cloudflareAccountId": {
+            "value": "[parameters('cloudflareAccountId')]"
           }
         },
         "template": {
@@ -633,7 +675,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.23.1.45101",
-              "templateHash": "6271026621046257363"
+              "templateHash": "4453945994355688786"
             }
           },
           "parameters": {
@@ -672,6 +714,18 @@
               "type": "string",
               "metadata": {
                 "description": "The resource ID of the Log Analytics Workspace for diagnostic settings."
+              }
+            },
+            "cloudflareApiToken": {
+              "type": "securestring",
+              "metadata": {
+                "description": "The Cloudflare API token for authenticating with Cloudflare Stream."
+              }
+            },
+            "cloudflareAccountId": {
+              "type": "string",
+              "metadata": {
+                "description": "The Cloudflare account ID used to identify the account when calling Cloudflare APIs."
               }
             }
           },
@@ -748,6 +802,28 @@
               "dependsOn": [
                 "[resourceId('Microsoft.KeyVault/vaults', parameters('name'))]"
               ]
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', parameters('name'), 'CloudflareApiToken')]",
+              "properties": {
+                "value": "[parameters('cloudflareApiToken')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', parameters('name'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2023-07-01",
+              "name": "[format('{0}/{1}', parameters('name'), 'CloudflareAccountId')]",
+              "properties": {
+                "value": "[parameters('cloudflareAccountId')]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults', parameters('name'))]"
+              ]
             }
           ],
           "outputs": {
@@ -780,6 +856,151 @@
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'function-app')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'monitoring')]",
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName')))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "event-grid",
+      "resourceGroup": "[format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "storageAccountName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'storage'), '2022-09-01').outputs.name.value]"
+          },
+          "storageAccountId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'storage'), '2022-09-01').outputs.id.value]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[variables('tags')]"
+          },
+          "functionAppHostName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'function-app'), '2022-09-01').outputs.defaultHostName.value]"
+          },
+          "functionAppId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'function-app'), '2022-09-01').outputs.id.value]"
+          },
+          "enableEventGrid": {
+            "value": "[parameters('enableEventGrid')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.23.1.45101",
+              "templateHash": "15840280129511147044"
+            }
+          },
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the storage account used as the Event Grid source."
+              }
+            },
+            "storageAccountId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the storage account used as the Event Grid source."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "The Azure region in which to deploy Event Grid resources."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Tags to apply to Event Grid resources."
+              }
+            },
+            "functionAppHostName": {
+              "type": "string",
+              "metadata": {
+                "description": "The default hostname of the Function App webhook target."
+              }
+            },
+            "functionAppId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the Function App."
+              }
+            },
+            "enableEventGrid": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Whether to deploy Event Grid resources. Set to false for initial deployment, true after the Function App is running."
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableEventGrid')]",
+              "type": "Microsoft.EventGrid/systemTopics",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}-evgt', parameters('storageAccountName'))]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "source": "[parameters('storageAccountId')]",
+                "topicType": "Microsoft.Storage.StorageAccounts"
+              }
+            },
+            {
+              "condition": "[parameters('enableEventGrid')]",
+              "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+              "apiVersion": "2022-06-15",
+              "name": "[format('{0}/{1}', format('{0}-evgt', parameters('storageAccountName')), format('{0}-evgs', parameters('storageAccountName')))]",
+              "properties": {
+                "filter": {
+                  "subjectBeginsWith": "/blobServices/default/containers/status-videos/blobs/uploads/",
+                  "includedEventTypes": [
+                    "Microsoft.Storage.BlobCreated"
+                  ]
+                },
+                "destination": {
+                  "endpointType": "WebHook",
+                  "properties": {
+                    "endpointUrl": "[format('https://{0}/runtime/webhooks/eventgrid?functionName=ProcessVideo&code={1}', parameters('functionAppHostName'), if(parameters('enableEventGrid'), listKeys(format('{0}/host/default', parameters('functionAppId')), '2024-04-01').systemKeys.eventgrid_extension, ''))]"
+                  }
+                },
+                "deadLetterDestination": {
+                  "endpointType": "StorageBlob",
+                  "properties": {
+                    "resourceId": "[parameters('storageAccountId')]",
+                    "blobContainerName": "status-videos"
+                  }
+                },
+                "retryPolicy": {
+                  "maxDeliveryAttempts": 30,
+                  "eventTimeToLiveInMinutes": 1440
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.EventGrid/systemTopics', format('{0}-evgt', parameters('storageAccountName')))]"
+              ]
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'function-app')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-standup-{1}', variables('abbrs').resourceGroup, parameters('environmentName'))), 'Microsoft.Resources/deployments', 'storage')]"
       ]
     },
     {

--- a/infra/modules/event-grid.bicep
+++ b/infra/modules/event-grid.bicep
@@ -58,6 +58,7 @@ resource blobCreatedSubscription 'Microsoft.EventGrid/systemTopics/eventSubscrip
 			properties: {
 				resourceId: storageAccountId
 				blobContainerName: 'status-videos'
+				blobPrefix: 'deadletter/'
 			}
 		}
 		retryPolicy: {

--- a/infra/modules/event-grid.bicep
+++ b/infra/modules/event-grid.bicep
@@ -1,0 +1,68 @@
+// Copyright 2026 Michael F. Collins, III
+// Licensed under the Naked Standup Source-Available Temporary License
+// See LICENSE.md for license terms.
+
+@description('The name of the storage account used as the Event Grid source.')
+param storageAccountName string
+
+@description('The resource ID of the storage account used as the Event Grid source.')
+param storageAccountId string
+
+@description('The Azure region in which to deploy Event Grid resources.')
+param location string
+
+@description('Tags to apply to Event Grid resources.')
+param tags object = {}
+
+@description('The default hostname of the Function App webhook target.')
+param functionAppHostName string
+
+@description('The resource ID of the Function App.')
+param functionAppId string
+
+@description('Whether to deploy Event Grid resources. Set to false for initial deployment, true after the Function App is running.')
+param enableEventGrid bool = false
+
+resource eventGridSystemTopic 'Microsoft.EventGrid/systemTopics@2022-06-15' = if (enableEventGrid) {
+	name: '${storageAccountName}-evgt'
+	location: location
+	tags: tags
+	properties: {
+		source: storageAccountId
+		topicType: 'Microsoft.Storage.StorageAccounts'
+	}
+}
+
+var eventGridSystemKey = enableEventGrid
+	? listKeys('${functionAppId}/host/default', '2024-04-01').systemKeys.eventgrid_extension
+	: ''
+
+resource blobCreatedSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2022-06-15' = if (enableEventGrid) {
+	parent: eventGridSystemTopic
+	name: '${storageAccountName}-evgs'
+	properties: {
+		filter: {
+			subjectBeginsWith: '/blobServices/default/containers/status-videos/blobs/uploads/'
+			includedEventTypes: [
+				'Microsoft.Storage.BlobCreated'
+			]
+		}
+		destination: {
+			endpointType: 'WebHook'
+			properties: {
+				endpointUrl: 'https://${functionAppHostName}/runtime/webhooks/eventgrid?functionName=ProcessVideo&code=${eventGridSystemKey}'
+			}
+		}
+		deadLetterDestination: {
+			endpointType: 'StorageBlob'
+			properties: {
+				resourceId: storageAccountId
+				blobContainerName: 'status-videos'
+			}
+		}
+		retryPolicy: {
+			maxDeliveryAttempts: 30
+			eventTimeToLiveInMinutes: 1440
+		}
+	}
+}

--- a/infra/modules/function-app.bicep
+++ b/infra/modules/function-app.bicep
@@ -26,6 +26,9 @@ param storageAccountBlobEndpoint string
 @description('The connection string for the Application Insights instance.')
 param appInsightsConnectionString string
 
+@description('The name of the Key Vault containing Cloudflare credentials.')
+param keyVaultName string
+
 // Storage Blob Delegator role — allows GetUserDelegationKey
 var storageBlobDelegatorRoleId = 'db58b8e5-c6ad-4a2a-8342-4190687cbf4a'
 
@@ -96,6 +99,14 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
 				{
 					name: 'AZURE_STORAGE_BLOB_ENDPOINT'
 					value: storageAccountBlobEndpoint
+				}
+				{
+					name: 'CLOUDFLARE_ACCOUNT_ID'
+					value: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=CloudflareAccountId)'
+				}
+				{
+					name: 'CLOUDFLARE_API_TOKEN'
+					value: '@Microsoft.KeyVault(VaultName=${keyVaultName};SecretName=CloudflareApiToken)'
 				}
 			]
 		}

--- a/infra/modules/key-vault.bicep
+++ b/infra/modules/key-vault.bicep
@@ -20,6 +20,13 @@ param apimPrincipalId string
 @description('The resource ID of the Log Analytics Workspace for diagnostic settings.')
 param logAnalyticsWorkspaceId string
 
+@description('The Cloudflare API token for authenticating with Cloudflare Stream.')
+@secure()
+param cloudflareApiToken string
+
+@description('The Cloudflare account ID used to identify the account when calling Cloudflare APIs.')
+param cloudflareAccountId string
+
 // Key Vault Secrets Officer role — allows the Function App to set the host key secret
 var keyVaultSecretsOfficerRoleId = 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7'
 
@@ -90,3 +97,19 @@ output name string = keyVault.name
 
 @description('The URI of the Key Vault.')
 output vaultUri string = keyVault.properties.vaultUri
+
+resource cloudflareApiTokenSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+	parent: keyVault
+	name: 'CloudflareApiToken'
+	properties: {
+		value: cloudflareApiToken
+	}
+}
+
+resource cloudflareAccountIdSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+	parent: keyVault
+	name: 'CloudflareAccountId'
+	properties: {
+		value: cloudflareAccountId
+	}
+}

--- a/infra/modules/monitoring.bicep
+++ b/infra/modules/monitoring.bicep
@@ -44,11 +44,9 @@ output id string = applicationInsights.id
 output name string = applicationInsights.name
 
 @description('The connection string for the Application Insights instance.')
-@secure()
 output connectionString string = applicationInsights.properties.ConnectionString
 
 @description('The instrumentation key for the Application Insights instance.')
-@secure()
 output instrumentationKey string = applicationInsights.properties.InstrumentationKey
 
 @description('The resource ID of the Log Analytics Workspace.')

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -41,40 +41,6 @@ resource statusVideosContainer 'Microsoft.Storage/storageAccounts/blobServices/c
 	}
 }
 
-// resource eventGridSystemTopic 'Microsoft.EventGrid/systemTopics@2022-06-15' = {
-// 	name: '${name}-evgt'
-// 	location: location
-// 	tags: tags
-// 	properties: {
-// 		source: storageAccount.id
-// 		topicType: 'Microsoft.Storage.StorageAccounts'
-// 	}
-// }
-
-// resource blobCreatedSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2022-06-15' = {
-// 	parent: eventGridSystemTopic
-// 	name: '${name}-evgs'
-// 	properties: {
-// 		filter: {
-// 			subjectBeginsWith: '/blobServices/default/containers/status-videos/blobs/uploads/'
-// 			includedEventTypes: [
-// 				'Microsoft.Storage.BlobCreated'
-// 			]
-// 		}
-// 		destination: {
-// 			endpointType: 'WebHook'
-// 			properties: {
-// 				// Placeholder webhook URL — replace with actual processing function endpoint
-// 				endpointUrl: 'https://placeholder.example.com/api/process-video'
-// 			}
-// 		}
-// 		retryPolicy: {
-// 			maxDeliveryAttempts: 3
-// 			eventTimeToLiveInMinutes: 30
-// 		}
-// 	}
-// }
-
 @description('The resource ID of the storage account.')
 output id string = storageAccount.id
 

--- a/specs/003-stream-video-transcoding/checklists/requirements.md
+++ b/specs/003-stream-video-transcoding/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Stream Video Transcoding via Cloudflare Stream
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation on the first iteration.
+- The spec intentionally uses "transcoding service" as the generic term in requirements and success criteria, keeping them technology-agnostic. The feature description and input reference Cloudflare Stream specifically, which will be addressed during planning.
+- Event Grid and SAS URL are referenced by their domain names as established in ADR-002 and Feature 002. These are architectural concepts in the project vocabulary, not implementation details.

--- a/specs/003-stream-video-transcoding/contracts/cloudflare-stream-api.md
+++ b/specs/003-stream-video-transcoding/contracts/cloudflare-stream-api.md
@@ -1,0 +1,170 @@
+# API Contract: Cloudflare Stream — Upload from URL
+
+**Base URL**: `https://api.cloudflare.com/client/v4/accounts/{account_id}`
+**Authentication**: Bearer token via `Authorization` header (API Token with "Stream Write" permission)
+**Direction**: Consumed by ProcessVideo function (server-to-server)
+
+---
+
+## POST /stream/copy
+
+Submit a video URL for transcoding and on-demand streaming delivery.
+
+### Request
+
+**Headers**:
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Authorization` | Yes | `Bearer <API_TOKEN>` — Cloudflare API token with Stream Write permission |
+| `Content-Type` | Yes | `application/json` |
+
+**Body** (`application/json`):
+
+```json
+{
+  "url": "https://ststandup.blob.core.windows.net/status-videos/uploads/anonymous/550e8400-e29b-41d4-a716-446655440000.mp4?sv=2024-11-04&st=...&se=...&sr=b&sp=r&sig=...",
+  "meta": {
+    "blobPath": "uploads/anonymous/550e8400-e29b-41d4-a716-446655440000.mp4"
+  },
+  "requireSignedURLs": false
+}
+```
+
+| Field | Type | Required | Constraints | Description |
+|-------|------|----------|-------------|-------------|
+| `url` | `string` | Yes | Valid HTTPS URL; must support HEAD and GET range requests | Source video URL (our read SAS URL) |
+| `meta` | `object` | No | Keys and values must be strings | Arbitrary metadata stored with the video; we include `blobPath` to correlate back to the source blob |
+| `requireSignedURLs` | `boolean` | No | Default: `false` | Whether playback URLs require signed tokens |
+
+### Response
+
+**200 OK** (`application/json`):
+
+```json
+{
+  "result": {
+    "uid": "ea95132c15732412d22c1476fa83f27a",
+    "status": {
+      "state": "downloading",
+      "pctComplete": "0.000000",
+      "errorReasonCode": "",
+      "errorReasonText": ""
+    },
+    "playback": {
+      "hls": "https://customer-abcdefgh.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/manifest/video.m3u8",
+      "dash": "https://customer-abcdefgh.cloudflarestream.com/ea95132c15732412d22c1476fa83f27a/manifest/video.mpd"
+    },
+    "readyToStream": false,
+    "meta": {
+      "blobPath": "uploads/anonymous/550e8400-e29b-41d4-a716-446655440000.mp4"
+    }
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `result.uid` | `string` | Unique video identifier assigned by Cloudflare; used for status checks and playback |
+| `result.status.state` | `string` | Current processing state: `downloading`, `queued`, `inprogress`, `ready`, `error` |
+| `result.status.pctComplete` | `string` | Encoding progress as a decimal string (e.g., `"50.000000"`) |
+| `result.status.errorReasonCode` | `string` | Error code if `state` is `error`; empty otherwise |
+| `result.status.errorReasonText` | `string` | Human-readable error description if `state` is `error` |
+| `result.playback.hls` | `string` | HLS manifest URL (available regardless of processing state) |
+| `result.playback.dash` | `string` | DASH manifest URL (available regardless of processing state) |
+| `result.readyToStream` | `boolean` | `true` when the video is ready for playback |
+| `result.meta` | `object` | Metadata provided in the request |
+| `success` | `boolean` | `true` if the request was accepted |
+| `errors` | `array` | Empty on success; contains error objects on failure |
+| `messages` | `array` | Informational messages from the API |
+
+### Error Responses
+
+**400 Bad Request** — Invalid request body or missing required fields:
+
+```json
+{
+  "result": null,
+  "success": false,
+  "errors": [{ "code": 10005, "message": "Could not process request body" }],
+  "messages": []
+}
+```
+
+**401 Unauthorized** — Missing or invalid API token:
+
+```json
+{
+  "result": null,
+  "success": false,
+  "errors": [{ "code": 10000, "message": "Authentication error" }],
+  "messages": []
+}
+```
+
+**429 Too Many Requests** — Rate limit exceeded (>120 concurrent encoding jobs or >1200 requests per 5 minutes):
+
+```json
+{
+  "result": null,
+  "success": false,
+  "errors": [{ "code": 10004, "message": "Too many requests" }],
+  "messages": []
+}
+```
+
+**500 Internal Server Error** — Cloudflare server-side failure:
+
+```json
+{
+  "result": null,
+  "success": false,
+  "errors": [{ "code": 10001, "message": "Server error" }],
+  "messages": []
+}
+```
+
+### Behavior Notes
+
+- The API returns immediately after accepting the URL. Transcoding is asynchronous — the `result.status.state` will be `downloading` initially.
+- The source URL must be accessible via HTTPS and must support HTTP HEAD and byte-range GET requests. Azure Blob Storage SAS URLs satisfy both requirements.
+- Cloudflare downloads the video from the source URL — the video bytes do not flow through our Function App.
+- The `uid` in the response is the primary identifier for all future operations on this video (status checks, playback, deletion).
+- Cloudflare supports a maximum file size of 30 GB. Our platform enforces a 50 MB limit (per Feature 002), so this constraint is always satisfied.
+- Playback URLs (`hls`, `dash`) are returned immediately but will not serve video content until `readyToStream` becomes `true`.
+- If the source URL is unreachable or the download fails, the video state transitions to `error` with `errorReasonCode: ERR_FETCH_ORIGIN_ERROR`.
+
+### Processing State Transitions
+
+```
+downloading ──→ queued ──→ inprogress ──→ ready
+     │              │            │
+     └──→ error     └──→ error   └──→ error
+```
+
+| State | `readyToStream` | Description |
+|-------|-----------------|-------------|
+| `downloading` | `false` | Cloudflare is downloading the video from the source URL |
+| `queued` | `false` | Download complete; video is queued for encoding |
+| `inprogress` | `false` | Encoding in progress; `pctComplete` updates periodically |
+| `ready` | `true` | Video is ready for playback via HLS/DASH |
+| `error` | `false` | Processing failed; check `errorReasonCode` for details |
+
+### Rate Limits & Constraints
+
+| Constraint | Value | Impact |
+|-----------|-------|--------|
+| Concurrent encoding | 120 videos per account (queued + encoding) | Submissions beyond this return HTTP 429 |
+| API rate limit | ~1200 requests per 5 minutes | General Cloudflare API limit |
+| Max file size | 30 GB | Our 50 MB platform limit is well within |
+| Supported formats | MP4, MOV, MKV, AVI, WebM, and others | Our platform supports `video/mp4` and `video/quicktime` |
+
+### Authentication
+
+- The API token is stored in Azure Key Vault as a secret.
+- The ProcessVideo function retrieves the token via Key Vault reference in the Function App's application settings.
+- The token requires the "Stream Write" permission scope.
+- The Cloudflare Account ID is also stored in Key Vault as a secret to avoid exposure in configuration.

--- a/specs/003-stream-video-transcoding/contracts/event-grid-trigger.md
+++ b/specs/003-stream-video-transcoding/contracts/event-grid-trigger.md
@@ -1,0 +1,139 @@
+# Event Contract: Blob Storage → Event Grid → ProcessVideo
+
+**Direction**: Inbound — Azure Event Grid delivers events to the ProcessVideo function
+**Event Source**: Azure Blob Storage system topic
+**Event Schema**: Event Grid schema (not CloudEvents)
+
+---
+
+## Event Grid System Topic
+
+| Property | Value |
+|----------|-------|
+| Topic type | `Microsoft.Storage.StorageAccounts` |
+| Source resource | Storage account (`ststandup{token}`) |
+| Schema | Event Grid schema |
+
+---
+
+## Event Subscription: ProcessVideo
+
+| Property | Value |
+|----------|-------|
+| Event types | `Microsoft.Storage.BlobCreated` |
+| Subject filter (begins with) | `/blobServices/default/containers/status-videos/blobs/uploads/` |
+| Endpoint type | Webhook |
+| Endpoint URL | `https://{functionApp}.azurewebsites.net/runtime/webhooks/eventgrid?functionName=ProcessVideo&code={systemKey}` |
+| Max delivery attempts | 30 |
+| Event time-to-live | 1440 minutes (24 hours) |
+| Dead-letter destination | `status-videos` container, `deadletter/` path |
+
+### Webhook Endpoint Notes
+
+- The endpoint URL uses the Functions runtime's built-in Event Grid webhook handler at `/runtime/webhooks/eventgrid`.
+- The `functionName` query parameter routes the event to the `ProcessVideo` function.
+- The `code` query parameter is the `eventgrid_extension` system key, automatically created by the Functions runtime when it loads the Event Grid extension.
+- The Functions runtime handles the Event Grid subscription validation handshake automatically.
+- The system key is retrieved in Bicep via: `listKeys('${functionAppId}/host/default', '2024-04-01').systemKeys.eventgrid_extension`.
+
+---
+
+## BlobCreated Event
+
+**Event Type**: `Microsoft.Storage.BlobCreated`
+
+### Envelope
+
+```json
+[
+  {
+    "id": "b0c0e7f0-4f6d-4b7a-8c9d-1e2f3a4b5c6d",
+    "topic": "/subscriptions/{subId}/resourceGroups/{rg}/providers/Microsoft.Storage/storageAccounts/{account}",
+    "subject": "/blobServices/default/containers/status-videos/blobs/uploads/anonymous/550e8400-e29b-41d4-a716-446655440000.mp4",
+    "eventType": "Microsoft.Storage.BlobCreated",
+    "eventTime": "2026-03-23T14:30:00.0000000Z",
+    "dataVersion": "",
+    "metadataVersion": "1",
+    "data": {
+      "api": "PutBlob",
+      "clientRequestId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "requestId": "f0e1d2c3-b4a5-6789-0123-456789abcdef",
+      "eTag": "0x8DB12345ABCDEF0",
+      "contentType": "video/mp4",
+      "contentLength": 12345678,
+      "blobType": "BlockBlob",
+      "url": "https://ststandup.blob.core.windows.net/status-videos/uploads/anonymous/550e8400-e29b-41d4-a716-446655440000.mp4",
+      "sequencer": "00000000000000000000000000000123400000000000abcdef",
+      "storageDiagnostics": {
+        "batchId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+      }
+    }
+  }
+]
+```
+
+### Event Data Fields (`StorageBlobCreatedEventData`)
+
+| Field | Type | Description | Used By ProcessVideo |
+|-------|------|-------------|---------------------|
+| `api` | `string` | REST API that created the blob (`PutBlob`, `PutBlockList`, `CopyBlob`) | No |
+| `clientRequestId` | `string` | Client-provided request ID | No |
+| `requestId` | `string` | Service-generated request ID | No |
+| `eTag` | `string` | Entity tag — useful for idempotency checks (FR-008) | Yes |
+| `contentType` | `string` | MIME type of the uploaded blob | Yes — validated against supported formats (FR-010) |
+| `contentLength` | `long` | Size of the blob in bytes | Yes — validated against size limits |
+| `blobType` | `string` | `BlockBlob`, `PageBlob`, or `AppendBlob` | No |
+| `url` | `string` | Full URL of the created blob (without SAS token) | Yes — used to extract blob path for SAS URL generation |
+| `sequencer` | `string` | Opaque value for ordering events | No |
+
+### Trigger Binding
+
+The ProcessVideo function receives the event as an `EventGridEvent` object via the Event Grid trigger binding:
+
+```csharp
+[Function(nameof(ProcessVideo))]
+public async Task Run([EventGridTrigger] EventGridEvent eventGridEvent)
+{
+    var blobData = eventGridEvent.Data.ToObjectFromJson<StorageBlobCreatedEventData>();
+    // Validate: blobData.ContentType, blobData.ContentLength
+    // Extract blob path from blobData.Url
+    // Generate read SAS URL via ISasUrlService
+    // Submit to Cloudflare Stream via ICloudflareStreamService
+}
+```
+
+### Validation Rules (ProcessVideo)
+
+| Check | Condition | Action on Failure |
+|-------|-----------|-------------------|
+| Supported content type (FR-010) | `contentType` is `video/mp4` or `video/quicktime` | Log warning, acknowledge event, skip processing |
+| Within size limits | `contentLength` <= 52,428,800 (50 MB) | Log warning, acknowledge event, skip processing |
+| Idempotency (FR-008) | Event `eTag` has not been processed before | Log info, acknowledge event, skip duplicate |
+
+### Retry & Dead-Letter Policy
+
+| Property | Value | Rationale |
+|----------|-------|-----------|
+| Max delivery attempts | 30 | Allows extended recovery from transient failures |
+| Event time-to-live | 1440 minutes (24 hours) | Events expire after 24 hours if undeliverable |
+| Dead-letter container | `status-videos` | Same storage account for operational simplicity |
+| Dead-letter path | `deadletter/` | Isolates failed events from video uploads |
+
+Dead-lettered events should trigger an operational alert when the dead-letter blob count exceeds a threshold (per edge case: extended transcoding service outage).
+
+---
+
+## Local Development
+
+For local testing, events are delivered via HTTP POST to the Functions runtime:
+
+**Endpoint**: `POST http://localhost:7071/runtime/webhooks/EventGrid?functionName=ProcessVideo`
+
+**Headers**:
+
+| Header | Value |
+|--------|-------|
+| `aeg-event-type` | `Notification` |
+| `Content-Type` | `application/json` |
+
+**Body**: Event Grid event array (same JSON format as the envelope above).

--- a/specs/003-stream-video-transcoding/data-model.md
+++ b/specs/003-stream-video-transcoding/data-model.md
@@ -1,0 +1,228 @@
+# Data Model: Stream Video Transcoding via Cloudflare Stream
+
+**Date**: 2026-03-23
+**Phase**: 1 — Design & Contracts
+
+---
+
+## Entities
+
+### StorageBlobCreatedEventData (Azure SDK — consumed, not defined)
+
+The incoming event payload from Event Grid when a blob is created in the `status-videos` container. Deserialized from the `EventGridEvent.Data` property.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Url` | `string` | Full URL of the created blob |
+| `Api` | `string` | REST API that created the blob (`PutBlob`, `PutBlockList`, `CopyBlob`) |
+| `ContentType` | `string` | MIME type of the blob |
+| `ContentLength` | `long` | Size of the blob in bytes |
+| `BlobType` | `string` | `BlockBlob`, `PageBlob`, etc. |
+| `ETag` | `string` | Entity tag; useful for idempotency checks |
+
+**Source**: `Azure.Messaging.EventGrid.SystemEvents.StorageBlobCreatedEventData`
+
+**Validation Rules (applied by ProcessVideo function)**:
+- `ContentType` must be one of `video/mp4`, `video/quicktime`.
+- `ContentLength` must be > 0 and <= 52,428,800 (50 MB).
+- Blob path (parsed from `Url`) must start with `uploads/`.
+
+---
+
+### CloudflareStreamRequest (New — `api/Models/`)
+
+Request body sent to the Cloudflare Stream "Upload from URL" endpoint.
+
+| Field | Type | JSON Property | Description |
+|-------|------|---------------|-------------|
+| `Url` | `string` | `url` | Read SAS URL for the uploaded video blob |
+| `Meta` | `Dictionary<string, string>?` | `meta` | Optional metadata (e.g., blob path for traceability) |
+| `RequireSignedURLs` | `bool?` | `requireSignedURLs` | Whether playback URLs require signing |
+
+**Validation Rules**:
+- `Url` must be a valid HTTPS URI.
+- `Url` must contain a SAS token (query string includes `sig=`).
+
+---
+
+### CloudflareStreamResponse (New — `api/Models/`)
+
+Response from the Cloudflare Stream "Upload from URL" endpoint. Follows the Cloudflare v4 API envelope pattern.
+
+| Field | Type | JSON Property | Description |
+|-------|------|---------------|-------------|
+| `Success` | `bool` | `success` | Whether the API call succeeded |
+| `Result` | `CloudflareStreamResult?` | `result` | Video details on success; `null` on error |
+| `Errors` | `List<CloudflareError>` | `errors` | Error details when `Success` is `false` |
+| `Messages` | `List<CloudflareMessage>` | `messages` | Informational messages |
+
+### CloudflareStreamResult (New — `api/Models/`)
+
+The `result` object within the Cloudflare Stream response.
+
+| Field | Type | JSON Property | Description |
+|-------|------|---------------|-------------|
+| `Uid` | `string` | `uid` | Cloudflare Stream video identifier |
+| `ReadyToStream` | `bool` | `readyToStream` | Whether the video is playable |
+| `Status` | `CloudflareStatus` | `status` | Current processing status |
+| `Playback` | `CloudflarePlayback?` | `playback` | Playback URLs (available when ready) |
+
+### CloudflareStatus (New — `api/Models/`)
+
+| Field | Type | JSON Property | Description |
+|-------|------|---------------|-------------|
+| `State` | `string` | `state` | Processing state: `downloading`, `queued`, `inprogress`, `ready`, `error` |
+| `PctComplete` | `string?` | `pctComplete` | Percentage complete during encoding |
+| `ErrorReasonCode` | `string?` | `errorReasonCode` | Error code if `State` is `error` |
+| `ErrorReasonText` | `string?` | `errorReasonText` | Human-readable error description |
+
+### CloudflarePlayback (New — `api/Models/`)
+
+| Field | Type | JSON Property | Description |
+|-------|------|---------------|-------------|
+| `Hls` | `string?` | `hls` | HLS manifest URL |
+| `Dash` | `string?` | `dash` | DASH manifest URL |
+
+### CloudflareError (New — `api/Models/`)
+
+| Field | Type | JSON Property | Description |
+|-------|------|---------------|-------------|
+| `Code` | `int` | `code` | Numeric error code |
+| `Message` | `string` | `message` | Error description |
+
+### CloudflareMessage (New — `api/Models/`)
+
+| Field | Type | JSON Property | Description |
+|-------|------|---------------|-------------|
+| `Code` | `int` | `code` | Numeric message code |
+| `Message` | `string` | `message` | Informational text |
+
+---
+
+### SasUrlResult (Existing — `api/Services/ISasUrlService.cs`)
+
+Already defined. Used for both write SAS (existing) and read SAS (new method).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `SasUri` | `Uri` | Full blob URL with SAS token appended |
+| `ExpiresAt` | `DateTimeOffset` | When the SAS URL expires |
+
+**Extended Usage**: The new `GenerateReadSasUrlAsync` method returns the same `SasUrlResult` record, with `BlobSasPermissions.Read` and a 60-minute expiry window.
+
+---
+
+## State Transitions
+
+### Cloudflare Stream Video Processing States
+
+```
+┌──────────────┐  download    ┌────────┐  encoding    ┌─────────────┐  complete    ┌────────┐
+│ downloading  │─────done────▶│ queued │─────start───▶│ inprogress  │────done─────▶│ ready  │
+└──────────────┘              └────────┘              └─────────────┘              └────────┘
+       │                           │                        │
+       │ fetch error               │ encoding error         │ encoding error
+       ▼                           ▼                        ▼
+   ┌────────┐                  ┌────────┐               ┌────────┐
+   │ error  │                  │ error  │               │ error  │
+   └────────┘                  └────────┘               └────────┘
+```
+
+| State | `readyToStream` | Description |
+|-------|-----------------|-------------|
+| `downloading` | `false` | Cloudflare is downloading the video from our SAS URL |
+| `queued` | `false` | Download complete, awaiting encoding slot |
+| `inprogress` | `false` | Encoding in progress; `pctComplete` updates periodically |
+| `ready` | `true` | Video is playable via HLS/DASH |
+| `error` | `false` | Processing failed — check `errorReasonCode` |
+
+**Error Codes**:
+
+| Code | Description | Our Response |
+|------|-------------|--------------|
+| `ERR_NON_VIDEO` | File is not a recognized video format | Log as permanent failure |
+| `ERR_FETCH_ORIGIN_ERROR` | Could not download from SAS URL (expired, 403, 404) | Log as permanent failure |
+| `ERR_MALFORMED_VIDEO` | Corrupt or undecodable video | Log as permanent failure |
+| `ERR_DURATION_EXCEED_CONSTRAINT` | Duration exceeds account constraint | Log as permanent failure |
+| `ERR_DURATION_TOO_SHORT` | Video too short | Log as permanent failure |
+
+---
+
+### ProcessVideo Function Event Flow
+
+```
+    Event Grid delivers BlobCreated event
+                    │
+                    ▼
+    ┌───────────────────────────────┐
+    │  Validate event (content type, │
+    │  size, path prefix)           │
+    └───────────────┬───────────────┘
+                    │
+            valid   │   invalid
+         ┌──────────┴──────────┐
+         ▼                     ▼
+    Generate read         Log skip,
+    SAS URL               acknowledge event
+         │
+         ▼
+    Submit SAS URL
+    to Cloudflare Stream
+         │
+    ┌────┴────┐
+    │ success │  failure
+    ▼         ▼
+  Log UID   Throw exception
+  + store   (runtime retries
+  result     via Event Grid
+              retry policy)
+```
+
+---
+
+## Relationships
+
+```
+Feature 002: CreateVideo (POST /video)
+       │
+       │ uploads blob to status-videos/uploads/{userId}/{uuid}.{ext}
+       ▼
+Azure Blob Storage ── Event Grid ──▶ ProcessVideo Function
+       │                                     │
+       │ blob read via SAS URL               │ submit SAS URL
+       │◀────────────────────────────────────┘
+       │
+       │ Cloudflare downloads via SAS URL
+       ▼
+Cloudflare Stream ── transcodes ──▶ HLS/DASH playback URLs
+```
+
+- A **blob upload** (from Feature 002) triggers exactly one **BlobCreated event**.
+- Event Grid may deliver the event more than once; the function handles duplicates idempotently.
+- The **ProcessVideo function** generates one **read SAS URL** per event and submits it to **Cloudflare Stream**.
+- Cloudflare Stream returns a **video UID** that uniquely identifies the transcoding job and is associated with the original blob path for status tracking.
+- One uploaded blob maps to exactly one Cloudflare Stream video UID.
+
+---
+
+## Storage
+
+### Azure Blob Storage
+
+- **Container**: `status-videos` (existing)
+- **Blob path format**: `uploads/{userId}/{uuid}.{extension}` (created by Feature 002)
+- **Event Grid filter**: `/blobServices/default/containers/status-videos/blobs/uploads/`
+- **Events**: `Microsoft.Storage.BlobCreated`
+- **No new storage containers** are needed for this feature.
+
+### Azure Key Vault
+
+- **`CloudflareStreamApiToken`**: Cloudflare API token with "Stream Write" permission
+- **`CloudflareStreamAccountId`**: Cloudflare account identifier
+
+Both secrets are referenced by the Function App via Key Vault references in app settings.
+
+### Application Logging
+
+- **Application Insights**: All processing attempts logged with blob path, content type, content length, Cloudflare video UID (on success), and error details (on failure).
+- **Structured logging**: Uses `ILogger<ProcessVideo>` with semantic log properties for queryability.

--- a/specs/003-stream-video-transcoding/data-model.md
+++ b/specs/003-stream-video-transcoding/data-model.md
@@ -217,8 +217,8 @@ Cloudflare Stream ── transcodes ──▶ HLS/DASH playback URLs
 
 ### Azure Key Vault
 
-- **`CloudflareStreamApiToken`**: Cloudflare API token with "Stream Write" permission
-- **`CloudflareStreamAccountId`**: Cloudflare account identifier
+- **`CloudflareApiToken`** (previously documented as `CloudflareStreamApiToken`): Cloudflare API token with "Stream Write" permission
+- **`CloudflareAccountId`** (previously documented as `CloudflareStreamAccountId`): Cloudflare account identifier
 
 Both secrets are referenced by the Function App via Key Vault references in app settings.
 

--- a/specs/003-stream-video-transcoding/plan.md
+++ b/specs/003-stream-video-transcoding/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: Stream Video Transcoding via Cloudflare Stream
+
+**Branch**: `003-stream-video-transcoding` | **Date**: 2026-03-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/003-stream-video-transcoding/spec.md`
+
+## Summary
+
+This feature connects the video upload pipeline (Feature 002) to streaming delivery by automatically transcoding uploaded videos via Cloudflare Stream. The implementation spans two domains:
+
+1. **Azure Functions** — A new Event Grid–triggered Azure Function (`ProcessVideo`) that fires when a video blob is created in the `status-videos/uploads/` path. The function generates a time-limited read SAS URL for the uploaded blob and submits it to the Cloudflare Stream "Upload from URL" API, which downloads and transcodes the video for on-demand streaming playback. Cloudflare API credentials are stored in Azure Key Vault and accessed via managed identity.
+
+2. **Azure Infrastructure** — A new Bicep module (`event-grid.bicep`) to deploy the Event Grid system topic and event subscription, wired to deliver `BlobCreated` events to the new processing function. The event subscription includes retry policy and dead-letter configuration. A two-pass bootstrap deployment is required because the Event Grid webhook endpoint needs the Function App's system key, which is only available after the function code is deployed.
+
+The function handles idempotency (duplicate events), content-type validation, and transient failure retry. Processing status is tracked via an internal record associating blob paths with Cloudflare Stream video UIDs.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 10.0
+**Primary Dependencies**: Azure Functions Worker v4, Azure.Storage.Blobs 12.23.0, Azure.Identity 1.13.2, Microsoft.Azure.Functions.Worker.Extensions.EventGrid 3.6.0, HttpClient (Cloudflare Stream API)
+**Storage**: Azure Blob Storage (video files in `status-videos` container)
+**Testing**: xUnit 2.9.2, Moq 4.20.72
+**Target Platform**: Azure Functions Flex Consumption (FC1, Linux, .NET 10 isolated worker)
+**Project Type**: Serverless functions / cloud API + infrastructure-as-code
+**Performance Goals**: Transcoding submission within 2 minutes of upload completion (SC-001); <1s p95 for read SAS URL generation
+**Constraints**: Videos <50 MB, read SAS URL ~1 hour expiry, Cloudflare Stream API rate limits (120 concurrent encoding jobs per account, ~1200 requests/5 min)
+**Scale/Scope**: Single Function App, single storage account, single Cloudflare Stream account
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+*Post-Phase 1 re-evaluation: All 8 principles confirmed PASS. No design drift detected.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Ship Often | PASS | Feature is scoped to Event Grid trigger + Cloudflare Stream submission. Playback integration, webhooks, and video deletion are explicitly out of scope. Status tracking (P2) is included but lightweight — just recording the Cloudflare video UID. |
+| II. Keep Quality High | PASS | TDD workflow for new ProcessVideo function and Cloudflare service. xUnit + Moq. ADR for upload architecture (002) exists; new ADR for transcoding integration not required unless architectural decisions deviate. |
+| III. Solicit Feedback | PASS | Processing status tracking enables downstream features to surface video readiness to users. Logging and monitoring provide operational visibility. |
+| IV. Security by Default | PASS | Cloudflare API credentials stored in Azure Key Vault, accessed via managed identity. Read SAS URLs are time-limited (~1 hour), scoped to single blob, read-only, HTTPS-only. Server-to-server only — SAS URL never exposed to end users. No secrets in code or config. |
+| V. Infrastructure as Code | PASS | Event Grid system topic and event subscription managed via Bicep. Key Vault secrets for Cloudflare credentials provisioned via Bicep. No manual resource creation. |
+| VI. Conventional Commits | PASS | Standard commit workflow applies. |
+| VII. Simplicity | PASS | One new function, one new service interface (Cloudflare client). Extends existing SasUrlService for read SAS. Minimal new abstractions. No additional storage systems — idempotency check uses blob metadata or a simple approach without a new database. |
+| VIII. Accessibility | PASS | Backend-only feature — no direct UI changes. Transcoded videos will support captions/transcripts in future features. |
+
+**Gate result: PASS** — no violations. Proceed to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+api/
+├── Functions/
+│   ├── CreateVideo.cs           # (existing) POST /video endpoint
+│   └── ProcessVideo.cs          # (NEW) Event Grid trigger — processes uploaded videos
+├── Models/
+│   ├── CreateVideoRequest.cs    # (existing)
+│   ├── CreateVideoResponse.cs   # (existing)
+│   ├── ErrorResponse.cs         # (existing)
+│   ├── CloudflareStreamRequest.cs   # (NEW) Cloudflare "Upload from URL" API request model
+│   └── CloudflareStreamResponse.cs  # (NEW) Cloudflare "Upload from URL" API response model
+├── Services/
+│   ├── ISasUrlService.cs        # (MODIFIED) Add read SAS method
+│   ├── SasUrlService.cs         # (MODIFIED) Implement read SAS generation
+│   ├── ICloudflareStreamService.cs  # (NEW) Interface for Cloudflare Stream API
+│   └── CloudflareStreamService.cs   # (NEW) HTTP client for Cloudflare Stream "Upload from URL"
+├── Program.cs                   # (MODIFIED) Register new services and HttpClient
+├── Api.csproj                   # (MODIFIED) Add Event Grid trigger package
+└── Api.Tests/
+    └── Functions/
+        ├── CreateVideoTests.cs      # (existing)
+        └── ProcessVideoTests.cs     # (NEW) Unit tests for ProcessVideo function
+
+infra/
+├── main.bicep                   # (MODIFIED) Wire Event Grid outputs if needed
+└── modules/
+    ├── storage.bicep            # (MODIFIED) Remove commented-out Event Grid resources (cleanup)
+    ├── event-grid.bicep         # (NEW) Event Grid system topic and event subscription
+    ├── function-app.bicep       # (MODIFIED) Add Cloudflare credential app settings from Key Vault
+    └── key-vault.bicep          # (MODIFIED) Add Cloudflare API key and Account ID secrets
+```
+
+**Structure Decision**: Extends the existing `api/` project structure (Mobile + API pattern). New files follow established conventions — one function per file in `Functions/`, service interface + implementation in `Services/`, models in `Models/`. No new projects needed; all code lives in the existing `Standup.Api` project and `Standup.Api.Tests` test project.
+
+## Complexity Tracking
+
+No constitution violations — no entries required.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| *(none)* | — | — |

--- a/specs/003-stream-video-transcoding/quickstart.md
+++ b/specs/003-stream-video-transcoding/quickstart.md
@@ -1,0 +1,167 @@
+# Quickstart: Stream Video Transcoding via Cloudflare Stream
+
+**Feature Branch**: `003-stream-video-transcoding`
+**Prerequisites**: Azure CLI, Azure Developer CLI (`azd`), .NET 10 SDK, Azure Functions Core Tools v4
+
+---
+
+## 1. Configure Cloudflare Credentials
+
+Store Cloudflare credentials in `local.settings.json` for local development:
+
+```json
+{
+  "Values": {
+    "CLOUDFLARE_ACCOUNT_ID": "<your-cloudflare-account-id>",
+    "CLOUDFLARE_API_TOKEN": "<your-cloudflare-api-token>"
+  }
+}
+```
+
+The API token requires the **Stream Write** permission scope. Create one at:
+**Cloudflare Dashboard → My Profile → API Tokens → Create Token → Custom Token**
+
+For deployed environments, these values are stored in Azure Key Vault and referenced via Function App application settings.
+
+## 2. Build and Run Locally
+
+```bash
+cd api
+dotnet restore      # Pulls new EventGrid extension package
+dotnet build
+func start          # Runs the Function App locally
+```
+
+The Function App runs at `http://localhost:7071`. You need:
+- Azure CLI login (`az login`) so `DefaultAzureCredential` can authenticate for SAS URL generation.
+- `AZURE_STORAGE_BLOB_ENDPOINT` in `local.settings.json` pointing to a storage account (Azurite does not support user delegation keys — use a real storage account for SAS testing).
+
+## 3. Test the ProcessVideo Function Locally
+
+Event Grid triggers can be tested locally via HTTP POST. Send a simulated `BlobCreated` event:
+
+```bash
+curl -X POST "http://localhost:7071/runtime/webhooks/EventGrid?functionName=ProcessVideo" \
+  -H "Content-Type: application/json" \
+  -H "aeg-event-type: Notification" \
+  -d '[{
+    "id": "test-event-001",
+    "topic": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Storage/storageAccounts/sttest",
+    "subject": "/blobServices/default/containers/status-videos/blobs/uploads/anonymous/test-video.mp4",
+    "eventType": "Microsoft.Storage.BlobCreated",
+    "eventTime": "2026-03-23T14:30:00Z",
+    "dataVersion": "",
+    "metadataVersion": "1",
+    "data": {
+      "api": "PutBlob",
+      "clientRequestId": "00000000-0000-0000-0000-000000000001",
+      "requestId": "00000000-0000-0000-0000-000000000002",
+      "eTag": "0x8DB12345ABCDEF0",
+      "contentType": "video/mp4",
+      "contentLength": 1024000,
+      "blobType": "BlockBlob",
+      "url": "https://ststandup.blob.core.windows.net/status-videos/uploads/anonymous/test-video.mp4",
+      "sequencer": "0000000000000000000000000000012340000000000abcdef",
+      "storageDiagnostics": { "batchId": "test-batch" }
+    }
+  }]'
+```
+
+**Expected result**: The function generates a read SAS URL for the blob and submits it to the Cloudflare Stream API. Check the function logs for:
+- `Processing BlobCreated event for blob: uploads/anonymous/test-video.mp4`
+- `Generated read SAS URL, expires at: ...`
+- `Submitted to Cloudflare Stream, video UID: ...`
+
+## 4. Test Validation — Unsupported Content Type
+
+```bash
+curl -X POST "http://localhost:7071/runtime/webhooks/EventGrid?functionName=ProcessVideo" \
+  -H "Content-Type: application/json" \
+  -H "aeg-event-type: Notification" \
+  -d '[{
+    "id": "test-event-002",
+    "topic": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test/providers/Microsoft.Storage/storageAccounts/sttest",
+    "subject": "/blobServices/default/containers/status-videos/blobs/uploads/anonymous/readme.txt",
+    "eventType": "Microsoft.Storage.BlobCreated",
+    "eventTime": "2026-03-23T14:30:00Z",
+    "dataVersion": "",
+    "metadataVersion": "1",
+    "data": {
+      "api": "PutBlob",
+      "clientRequestId": "00000000-0000-0000-0000-000000000003",
+      "requestId": "00000000-0000-0000-0000-000000000004",
+      "eTag": "0x8DB12345ABCDEF1",
+      "contentType": "text/plain",
+      "contentLength": 256,
+      "blobType": "BlockBlob",
+      "url": "https://ststandup.blob.core.windows.net/status-videos/uploads/anonymous/readme.txt",
+      "sequencer": "0000000000000000000000000000012340000000000abcdf0",
+      "storageDiagnostics": { "batchId": "test-batch" }
+    }
+  }]'
+```
+
+**Expected result**: The function skips processing and logs a warning about unsupported content type.
+
+## 5. Run Unit Tests
+
+```bash
+cd api
+dotnet test
+```
+
+## 6. Deploy to Azure
+
+### First-Time Deployment (Two-Pass Bootstrap)
+
+On the first deployment, the Event Grid subscription cannot be created because the Function App code has not been deployed yet (the system key doesn't exist):
+
+```bash
+# Pass 1: Deploy infrastructure without Event Grid
+azd provision       # Uses enableEventGrid=false (default)
+
+# Deploy function code so the runtime creates the system key
+azd deploy
+
+# Pass 2: Enable Event Grid subscription
+azd provision --parameter enableEventGrid=true
+```
+
+### Subsequent Deployments
+
+After the initial bootstrap, the system key persists across deployments:
+
+```bash
+azd provision       # enableEventGrid=true in parameters file
+azd deploy
+```
+
+## 7. Verify End-to-End in Azure
+
+1. Upload a video through the iOS app or via the CreateVideo API (Feature 002)
+2. The upload creates a blob in `status-videos/uploads/`
+3. Event Grid emits a `BlobCreated` event → delivered to ProcessVideo function
+4. ProcessVideo generates a read SAS URL and submits to Cloudflare Stream
+5. Verify in Cloudflare Dashboard → **Stream → Videos** that the video appears with status `downloading` → `ready`
+
+### Check Function Logs
+
+```bash
+az monitor app-insights query \
+  --app {app-insights-name} \
+  --analytics-query "traces | where message contains 'ProcessVideo' | order by timestamp desc | take 10"
+```
+
+## 8. Key Vault Secrets (Deployed Environments)
+
+| Secret Name | Description |
+|-------------|-------------|
+| `CloudflareAccountId` | Cloudflare account identifier |
+| `CloudflareApiToken` | API token with Stream Write permission |
+
+These are referenced in the Function App's application settings as Key Vault references:
+
+```
+CLOUDFLARE_ACCOUNT_ID = @Microsoft.KeyVault(SecretUri=https://{vault}.vault.azure.net/secrets/CloudflareAccountId)
+CLOUDFLARE_API_TOKEN = @Microsoft.KeyVault(SecretUri=https://{vault}.vault.azure.net/secrets/CloudflareApiToken)
+```

--- a/specs/003-stream-video-transcoding/research.md
+++ b/specs/003-stream-video-transcoding/research.md
@@ -1,0 +1,203 @@
+# Research: Stream Video Transcoding via Cloudflare Stream
+
+**Date**: 2026-03-23
+
+---
+
+## R-001: Event Grid Trigger SDK for .NET Isolated Worker
+
+**Decision**: Use `Microsoft.Azure.Functions.Worker.Extensions.EventGrid` version 3.6.0.
+
+**Rationale**: This is the correct package for Event Grid triggers in the .NET isolated worker model (not the in-process WebJobs package). Version 3.6.0 supports SDK type bindings with `Azure.Messaging.EventGrid.EventGridEvent` and `Azure.Messaging.EventGrid.SystemEvents.StorageBlobCreatedEventData` for strongly-typed event deserialization.
+
+**Key Findings**:
+
+- Package: `Microsoft.Azure.Functions.Worker.Extensions.EventGrid` 3.6.0
+- Do NOT use `Microsoft.Azure.WebJobs.Extensions.EventGrid` (in-process model only)
+- Function signature uses `[EventGridTrigger] EventGridEvent` parameter type
+- `StorageBlobCreatedEventData` available via `eventGridEvent.Data.ToObjectFromJson<StorageBlobCreatedEventData>()`
+- Supports constructor DI natively in isolated worker model
+- Subscription validation handshake is handled automatically by the Functions runtime at `/runtime/webhooks/eventgrid`
+
+**Trigger Binding Syntax**:
+
+```csharp
+using Azure.Messaging.EventGrid;
+using Azure.Messaging.EventGrid.SystemEvents;
+using Microsoft.Azure.Functions.Worker;
+
+[Function(nameof(ProcessVideo))]
+public async Task Run([EventGridTrigger] EventGridEvent eventGridEvent)
+{
+    var blobData = eventGridEvent.Data.ToObjectFromJson<StorageBlobCreatedEventData>();
+    // blobData.Url, blobData.ContentType, blobData.ContentLength, blobData.Api
+}
+```
+
+**BlobCreated Event Schema** (key data fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Url` | `string` | Full blob URL |
+| `Api` | `string` | REST API that created the blob (`PutBlob`, `PutBlockList`, `CopyBlob`) |
+| `ContentType` | `string` | MIME type |
+| `ContentLength` | `long` | Size in bytes |
+| `BlobType` | `string` | `BlockBlob`, `PageBlob`, etc. |
+| `ETag` | `string` | Useful for idempotency |
+
+**Local Testing**: POST to `http://localhost:7071/runtime/webhooks/EventGrid?functionName=ProcessVideo` with `aeg-event-type: Notification` header and an Event Grid event array in the body.
+
+**Alternatives Considered**:
+
+| Alternative | Rejected Because |
+|------------|-----------------|
+| In-process model (`WebJobs.Extensions.EventGrid`) | Project uses isolated worker; incompatible |
+| CloudEvent schema | Event Grid system topic for Storage uses Event Grid schema by default; CloudEvent would require schema conversion |
+| Blob trigger instead of Event Grid | Higher latency (polling-based), less reliable for high-throughput, no filtering by path prefix |
+
+---
+
+## R-002: Cloudflare Stream "Upload from URL" API
+
+**Decision**: Use the Cloudflare Stream `POST /stream/copy` endpoint with Bearer token authentication.
+
+**Rationale**: This is the purpose-built Cloudflare API for submitting external URLs for transcoding. Azure Blob Storage SAS URLs are fully compatible (support HEAD and GET range requests). The API returns a video UID immediately that can be stored for future status checks and playback integration.
+
+**Key Findings**:
+
+- **Endpoint**: `POST https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/copy`
+- **Auth**: `Authorization: Bearer <API_TOKEN>` (API Token with "Stream Write" permission)
+- **Required field**: `url` — the source URL (our read SAS URL)
+- **Optional fields**: `meta` (key-value metadata), `allowedOrigins`, `requireSignedURLs`, `thumbnailTimestampPct`, `scheduledDeletion`
+- **Response**: Cloudflare v4 envelope with `result.uid`, `result.status.state`, `result.playback.hls`, `result.playback.dash`
+
+**Rate Limits**:
+
+| Limit | Value |
+|-------|-------|
+| Concurrent encoding | 120 videos per account (queued + encoding) |
+| API rate limit | ~1200 requests per 5 minutes (general Cloudflare API limit) |
+| Exceeding limits | HTTP 429 response |
+
+**Size Limits**:
+
+| Constraint | Value |
+|-----------|-------|
+| Max file size | 30 GB (our limit is 50 MB — well within) |
+| Supported formats | MP4, MOV, MKV, AVI, WebM, and others |
+
+**Processing States**:
+
+| State | `readyToStream` | Description |
+|-------|-----------------|-------------|
+| `downloading` | `false` | Cloudflare downloading from source URL |
+| `queued` | `false` | Download complete, awaiting encoding |
+| `inprogress` | `false` | Encoding in progress (`pctComplete` updates) |
+| `ready` | `true` | Playable via HLS/DASH |
+| `error` | `false` | Failed — check `errorReasonCode` |
+
+**Processing Error Codes**:
+
+| Code | Description |
+|------|-------------|
+| `ERR_NON_VIDEO` | File is not a recognized video format |
+| `ERR_FETCH_ORIGIN_ERROR` | Could not download from source URL (403, 404, timeout) |
+| `ERR_MALFORMED_VIDEO` | Corrupt or undecodable video |
+| `ERR_DURATION_EXCEED_CONSTRAINT` | Duration exceeds constraint |
+| `ERR_DURATION_TOO_SHORT` | Video too short |
+
+**Error Response Format**:
+
+```json
+{
+  "result": null,
+  "success": false,
+  "errors": [{ "code": 10005, "message": "Description" }],
+  "messages": []
+}
+```
+
+**Webhook Support**: Cloudflare supports webhooks for transcoding completion notifications. Registration via `PUT /stream/webhook` with a `notificationUrl`. Returns a `secret` for HMAC signature verification. This is out of scope for this feature but relevant for future status tracking.
+
+**Alternatives Considered**:
+
+| Alternative | Rejected Because |
+|------------|-----------------|
+| Direct upload (TUS protocol) | Requires streaming the video through our Function — unnecessary double-transfer of data |
+| Cloudflare R2 + Stream integration | Adds R2 dependency; SAS URL approach is simpler and uses existing Blob Storage |
+| Self-hosted transcoding (FFmpeg) | Constitution Principle VII (Simplicity) — Cloudflare handles transcoding, CDN delivery, and adaptive bitrate |
+
+---
+
+## R-003: Event Grid Subscription Deployment Ordering
+
+**Decision**: Extract Event Grid resources into a separate `event-grid.bicep` module that depends on both `storage` and `functionApp` modules. Use a conditional `enableEventGrid` parameter for first-time deployments.
+
+**Rationale**: The Event Grid event subscription performs a synchronous webhook validation handshake when created. The target Function App must be deployed, running, and have the `eventgrid_extension` system key available. This creates a dependency ordering challenge that is best solved by separating Event Grid into its own module.
+
+**Key Findings**:
+
+- **Problem**: Event Grid subscription creation sends a validation request to the webhook URL. If the Function App doesn't exist or the function code isn't deployed, the handshake fails and the Bicep deployment errors out.
+- **System key**: The `eventgrid_extension` system key is created by the Functions runtime when it loads the Event Grid extension, NOT when the Function App resource is provisioned. On first deploy, the key won't exist until the code is deployed and the app starts.
+- **listKeys syntax**: `listKeys('${functionAppId}/host/default', '2024-04-01').systemKeys.eventgrid_extension`
+- **Webhook URL format**: `https://{hostName}/runtime/webhooks/eventgrid?functionName=ProcessVideo&code={systemKey}`
+
+**Deployment Module Structure**:
+
+```
+monitoring → (no deps)
+storage → (no deps)
+functionApp → storage, monitoring
+eventGrid → storage, functionApp      ← NEW MODULE
+keyVault → functionApp
+apim → functionApp
+```
+
+**First-Time Bootstrap Strategy**:
+
+1. First deployment: `enableEventGrid = false` — deploys everything except Event Grid subscription
+2. Code deployment: `azd deploy` pushes function code, runtime starts, system key is created
+3. Second deployment: `enableEventGrid = true` — Event Grid subscription is created with valid webhook URL
+
+**Alternatives Considered**:
+
+| Alternative | Rejected Because |
+|------------|-----------------|
+| Event Grid resources inside `storage.bicep` | Creates circular dependency (storage ← functionApp but Event Grid needs functionApp) |
+| Pass functionApp outputs into storage module | Messier dependency graph; conflates storage and eventing concerns |
+| Azure CLI post-deployment script | Violates Constitution Principle V (Infrastructure as Code) — all resources must be in Bicep |
+| Blob trigger instead of Event Grid | Higher latency, no path filtering, less reliable at scale |
+
+---
+
+## R-004: Read SAS URL Generation for Cloudflare
+
+**Decision**: Extend the existing `ISasUrlService` with a `GenerateReadSasUrlAsync` method. Use 1-hour expiry, read-only permission, single-blob scope, HTTPS-only.
+
+**Rationale**: The existing `SasUrlService` already implements user delegation key–based SAS generation with the correct security patterns (managed identity, no shared keys). Adding a read method follows the same pattern with different permissions and longer expiry.
+
+**Key Findings**:
+
+- Existing service generates **write+create** SAS with 15-minute expiry
+- Read SAS needs: `BlobSasPermissions.Read`, ~60-minute expiry (per FR-003 in spec)
+- Cloudflare requires: HTTP HEAD and GET range requests — both work with read-only SAS
+- User delegation key validity: max 7 days; current code uses expiry-aligned keys
+- No code changes needed to `BlobServiceClient` registration — same client works for read SAS
+
+**Design Approach**:
+
+```csharp
+// New method on ISasUrlService
+Task<SasUrlResult> GenerateReadSasUrlAsync(string blobPath, CancellationToken cancellationToken = default);
+```
+
+The implementation mirrors `GenerateSasUrlAsync` but uses `BlobSasPermissions.Read` and a 60-minute expiry window.
+
+**Alternatives Considered**:
+
+| Alternative | Rejected Because |
+|------------|-----------------|
+| New service class for read SAS | Duplicates user delegation key logic; existing service already has the BlobServiceClient and pattern |
+| Account-level SAS | Overly broad permissions; violates least-privilege (Constitution Principle IV) |
+| Shared access key SAS | Storage account has shared key access disabled; only user delegation SAS is possible |
+| Pass blob URL directly without SAS | Container has no public access; Cloudflare can't download without auth |

--- a/specs/003-stream-video-transcoding/spec.md
+++ b/specs/003-stream-video-transcoding/spec.md
@@ -1,0 +1,142 @@
+# Feature Specification: Stream Video Transcoding via Cloudflare Stream
+
+**Feature Branch**: `003-stream-video-transcoding`
+**Created**: 2026-03-23
+**Status**: Draft
+**Input**: User description: "When a video is uploaded to Azure Blob Storage, an Event Grid event will be published (currently commented out in infra/modules/storage.bicep; it was put in here as a placeholder, but I commented it out because it was preventing deployment). We want to capture this event, create an SAS URL for reading, and send that URL to Cloudflare Stream using the Upload Videos from a URL API. Cloudflare Stream will then download the video from Blob Storage and will transcode the video for on-demand streaming playback."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Automatically Transcode Uploaded Video (Priority: P1)
+
+After a team member uploads a status video to the platform, the system automatically detects the new upload and submits the video to a transcoding service for processing. The team member does not need to take any action — the transcoding is triggered seamlessly by the upload event. Once transcoding begins, the video is queued with the transcoding provider and will be prepared for on-demand streaming playback.
+
+**Why this priority**: This is the core value of the feature. Without automatic detection and submission to the transcoding service, uploaded videos remain raw files in storage and can never be played back by other team members. This story connects the upload pipeline (Feature 002) to the streaming delivery pipeline, making uploaded videos useful.
+
+**Independent Test**: Can be fully tested by uploading a video to the `status-videos` container, verifying the system detects the upload event, generates a read URL for the video, and successfully submits it to the transcoding service. The transcoding service acknowledges receipt and begins processing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a video has been uploaded to the `status-videos` container, **When** the upload completes, **Then** the system detects the new blob via an event notification within 60 seconds.
+2. **Given** the system has detected a new video upload event, **When** it processes the event, **Then** it generates a time-limited read URL for the uploaded blob.
+3. **Given** the system has a read URL for the uploaded video, **When** it submits the URL to the transcoding service, **Then** the transcoding service accepts the submission and begins downloading the video.
+4. **Given** the transcoding service has accepted the video submission, **When** transcoding completes, **Then** the video is available for on-demand streaming playback.
+
+---
+
+### User Story 2 - Recover from Transcoding Submission Failure (Priority: P1)
+
+If the system fails to submit an uploaded video to the transcoding service (e.g., the transcoding service is temporarily unavailable or the request is rejected), the system retries the submission automatically. Transient failures do not cause videos to be lost or permanently stuck in an unprocessed state.
+
+**Why this priority**: Reliability of the processing pipeline is critical. If a single transient error causes a video to never be transcoded, the team member's update is lost to their colleagues. Retry logic is essential for a production-ready pipeline.
+
+**Independent Test**: Can be tested by simulating a failure in the transcoding service submission (e.g., the service returns a server error), verifying the system retries automatically, and confirming the video is eventually submitted when the service recovers.
+
+**Acceptance Scenarios**:
+
+1. **Given** the system attempts to submit a video to the transcoding service, **When** the submission fails with a transient error (e.g., timeout, service unavailable), **Then** the system retries the submission automatically.
+2. **Given** the system is retrying a failed submission, **When** the transient error resolves, **Then** the video is successfully submitted to the transcoding service.
+3. **Given** the system has exhausted all retry attempts, **When** the submission still fails, **Then** the failure is logged with enough detail to diagnose the issue and the event is sent to a dead-letter destination.
+
+---
+
+### User Story 3 - Track Video Processing Status (Priority: P2)
+
+After a video has been submitted to the transcoding service, the system tracks the processing status so that downstream features (e.g., playback, notification) can determine when a video is ready for streaming.
+
+**Why this priority**: While the core submission pipeline (P1) is the immediate deliverable, tracking the processing status is essential for any downstream consumer to know when the video is ready. Without it, there is no way to know when a video can be played back.
+
+**Independent Test**: Can be tested by submitting a video for transcoding and verifying that the system records the transcoding job identifier and can report the current status (e.g., queued, processing, ready, error).
+
+**Acceptance Scenarios**:
+
+1. **Given** the system has submitted a video to the transcoding service, **When** the submission succeeds, **Then** the system records the transcoding job identifier associated with the uploaded video.
+2. **Given** a transcoding job is in progress, **When** the status of the job is queried, **Then** the current processing state is returned (e.g., queued, processing, ready, error).
+3. **Given** transcoding has completed, **When** the status is queried, **Then** the system reports the video as ready for playback and provides the streaming playback information.
+
+---
+
+### User Story 4 - Enable Event Grid Infrastructure for Blob Upload Events (Priority: P1)
+
+The infrastructure that publishes events when a video is uploaded to blob storage needs to be enabled. Currently, the Event Grid system topic and event subscription resources are defined but commented out in the infrastructure templates because they were blocking deployment. The infrastructure must be updated so that blob-created events in the `status-videos` container are reliably published and delivered to the processing function.
+
+**Why this priority**: Without the event infrastructure in place, no upload events are raised and the entire processing pipeline cannot trigger. This is a prerequisite for all other stories.
+
+**Independent Test**: Can be tested by deploying the updated infrastructure, uploading a blob to the `status-videos` container, and verifying that the event is delivered to the configured endpoint.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Event Grid system topic and event subscription are deployed, **When** a blob is created in the `status-videos/uploads/` path, **Then** a `BlobCreated` event is delivered to the processing function endpoint.
+2. **Given** the Event Grid infrastructure is deployed, **When** the overall infrastructure deployment runs, **Then** deployment completes successfully without errors.
+3. **Given** the event subscription is configured, **When** an event delivery fails, **Then** the event is retried according to the configured retry policy and eventually sent to a dead-letter destination if all retries are exhausted.
+
+---
+
+### Edge Cases
+
+- What happens if the same blob-created event is delivered more than once? The processing function must handle duplicate events idempotently — if a video has already been submitted for transcoding, a duplicate event should not trigger a second submission.
+- What happens if the read URL expires before the transcoding service finishes downloading the video? The read URL must have a sufficient expiry window to allow the transcoding service to begin its download. A generous expiry (e.g., 1 hour) mitigates this risk without compromising security since the URL is only shared with the transcoding service via a server-to-server call.
+- What happens if the uploaded blob is deleted from storage before the transcoding service downloads it? The transcoding submission will fail. The system should log this as a permanent failure since the source video no longer exists.
+- What happens if the Event Grid subscription endpoint is unreachable during deployment (validation handshake fails)? The deployment will fail. The processing function must be deployed and reachable before the Event Grid subscription is created, or the subscription must use a mechanism that does not require endpoint validation at deployment time.
+- What happens if the blob-created event is for a non-video file (e.g., someone uploads a text file via the storage API)? The processing function should validate the content type of the blob. If it is not a supported video format, the event should be acknowledged without submitting for transcoding.
+- What happens if the transcoding service is down for an extended period? Events that cannot be delivered after all retries should be dead-lettered. An operational alert should be triggered when the dead-letter queue depth exceeds a threshold.
+- What happens if a very large video is uploaded that exceeds the transcoding service's size limits? The processing function should validate the blob size before submission and reject files that exceed the transcoding service's limits, logging the rejection.
+
+## Assumptions
+
+- Feature 002 (Video Upload Processing) has been implemented — the iOS client can upload videos to the `status-videos/uploads/` path in Azure Blob Storage via SAS URL.
+- The existing `SasUrlService` generates write+create SAS URLs. This feature requires generating read SAS URLs for a different purpose (allowing the transcoding service to download the video). The existing service will need to be extended or a new method added.
+- The transcoding service account and credentials are available and can be stored securely (e.g., in Azure Key Vault).
+- The transcoding service supports receiving a URL pointing to the source video and will download it for transcoding (URL-based upload).
+- Videos uploaded to the platform are short-form (30 seconds to a few minutes) and under 50 MB, well within the transcoding service's limits.
+- The processing function runs in the same Azure Functions app that hosts the existing `CreateVideo` function.
+- The read SAS URL shared with the transcoding service is only transmitted via a server-to-server HTTPS call and is never exposed to end users.
+
+## Out of Scope
+
+- **Playback integration**: Delivering transcoded video streams to the iOS client for playback. This feature covers submission to the transcoding service only; playback is a separate feature.
+- **Caption and transcript generation**: Generating captions or transcripts from the video audio. This may be handled by the transcoding service or a separate service, but is not part of this feature.
+- **Webhook processing from transcoding service**: Handling callbacks or webhooks from the transcoding service when transcoding completes. This may be part of a follow-on feature to update video status in real time.
+- **Video deletion**: Removing uploaded videos from blob storage after transcoding is complete. Retention policy is a separate concern.
+- **User-facing processing status UI**: Displaying processing status in the iOS app. This feature covers server-side status tracking only.
+- **Multi-region or CDN delivery**: Configuring content delivery or multi-region streaming. The transcoding service handles delivery natively.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST detect when a new video blob is created in the `status-videos/uploads/` path in blob storage by receiving an event notification.
+- **FR-002**: The system MUST generate a time-limited read URL for the uploaded video blob so that the transcoding service can download it.
+- **FR-003**: The read URL MUST expire after a limited time window sufficient for the transcoding service to begin downloading (approximately 1 hour).
+- **FR-004**: The system MUST submit the read URL to the transcoding service's URL-based upload endpoint to initiate transcoding for on-demand streaming playback.
+- **FR-005**: The system MUST include required authentication credentials when calling the transcoding service API.
+- **FR-006**: The transcoding service credentials MUST be stored securely and MUST NOT be hard-coded in source code or configuration files.
+- **FR-007**: The system MUST automatically retry transient failures when submitting to the transcoding service (e.g., timeouts, 5xx errors) before treating the submission as permanently failed.
+- **FR-008**: The system MUST handle duplicate event delivery idempotently — processing the same blob-created event more than once MUST NOT result in duplicate transcoding submissions.
+- **FR-009**: The system MUST log each video processing attempt with the blob path, transcoding job identifier (on success), and error details (on failure).
+- **FR-010**: The system MUST validate that the uploaded blob is a supported video format before submitting it for transcoding. Unsupported files MUST be acknowledged and skipped.
+- **FR-011**: The system MUST record the transcoding job identifier returned by the transcoding service so that the video's processing status can be tracked.
+- **FR-012**: The Event Grid system topic MUST be deployed to monitor the storage account for `BlobCreated` events.
+- **FR-013**: The Event Grid event subscription MUST filter events to only the `status-videos/uploads/` path within the `status-videos` container.
+- **FR-014**: The Event Grid event subscription MUST deliver events to the processing function endpoint.
+- **FR-015**: The Event Grid event subscription MUST have a retry policy and dead-letter destination for events that cannot be delivered after all retry attempts.
+- **FR-016**: The infrastructure deployment MUST succeed without errors when the Event Grid resources are included.
+
+### Key Entities
+
+- **Video Upload Event**: Represents the notification that a new video blob has been created in storage. Contains the blob path, blob URL, content type, and content length. Triggers the processing pipeline.
+- **Read URL**: A time-limited, read-only URL for the uploaded video blob. Generated by the system and shared with the transcoding service via a server-to-server call. Expires after a configured window (approximately 1 hour).
+- **Transcoding Job**: Represents the transcoding work initiated with the transcoding service. Has an identifier assigned by the transcoding service, a status (queued, processing, ready, error), and is associated with exactly one uploaded video blob.
+- **Processing Record**: An internal record that associates the uploaded blob path with the transcoding job identifier and tracks submission status (submitted, failed, dead-lettered). Used for idempotency checks and status tracking.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 99% of videos uploaded to the `status-videos` container trigger a transcoding submission within 2 minutes of upload completion.
+- **SC-002**: 95% of transcoding submissions succeed on the first attempt when the transcoding service is healthy.
+- **SC-003**: Transient submission failures are automatically retried, and 99% of videos are eventually submitted within 10 minutes of upload.
+- **SC-004**: No video is submitted for transcoding more than once due to duplicate event delivery.
+- **SC-005**: Transcoded videos are available for on-demand streaming playback within 10 minutes of upload completion for videos under 50 MB.
+- **SC-006**: All submission failures (transient and permanent) are logged with sufficient detail to diagnose the root cause without accessing the transcoding service's dashboard.
+- **SC-007**: Infrastructure deployment including Event Grid resources completes successfully in all environments (development, staging, production).

--- a/specs/003-stream-video-transcoding/tasks.md
+++ b/specs/003-stream-video-transcoding/tasks.md
@@ -1,0 +1,757 @@
+# Tasks: Stream Video Transcoding via Cloudflare Stream
+
+**Generated**: 2026-03-23
+**Feature Spec**: [spec.md](spec.md)
+**Implementation Plan**: [plan.md](plan.md)
+**Data Model**: [data-model.md](data-model.md)
+**API Contracts**: [contracts/cloudflare-stream-api.md](contracts/cloudflare-stream-api.md), [contracts/event-grid-trigger.md](contracts/event-grid-trigger.md)
+**Research**: [research.md](research.md)
+**Quickstart**: [quickstart.md](quickstart.md)
+
+---
+
+## Phase 1: Setup
+
+> Add the Event Grid trigger extension package to the Azure Functions project.
+
+- [ ] T001 Add EventGrid trigger package to `api/Api.csproj`
+
+### T001 Details
+
+Add `Microsoft.Azure.Functions.Worker.Extensions.EventGrid` version 3.6.0 to `api/Api.csproj`.
+
+This is the .NET isolated worker extension for Event Grid triggers. Do NOT use `Microsoft.Azure.WebJobs.Extensions.EventGrid` (in-process model only).
+
+See R-001 in research.md for package selection rationale.
+
+---
+
+## Phase 2: Foundational — Infrastructure (BLOCKS all user stories)
+
+> Deploy Azure infrastructure changes required before any function code can
+> operate: Event Grid event delivery, Cloudflare credential storage, and
+> application configuration. All user stories depend on this phase.
+
+- [ ] T002 [P] Create Event Grid Bicep module in `infra/modules/event-grid.bicep`
+- [ ] T003 [P] Modify Key Vault module to add Cloudflare secrets in `infra/modules/key-vault.bicep`
+- [ ] T004 [P] Modify Function App module to add Cloudflare app settings in `infra/modules/function-app.bicep`
+- [ ] T005 [P] Remove commented-out Event Grid resources from `infra/modules/storage.bicep`
+- [ ] T006 Wire Event Grid module and enableEventGrid parameter in `infra/main.bicep`
+
+### T002 Details
+
+Create `infra/modules/event-grid.bicep` as a new module (per R-003 in research.md).
+
+Resources:
+
+- **System Topic** (`Microsoft.EventGrid/systemTopics`): Source type
+  `Microsoft.Storage.StorageAccounts`, linked to the storage account.
+- **Event Subscription** (`Microsoft.EventGrid/systemTopics/eventSubscriptions`):
+  - Filter: `Microsoft.Storage.BlobCreated` events only
+  - Subject begins with:
+    `/blobServices/default/containers/status-videos/blobs/uploads/`
+  - Webhook endpoint:
+    `https://{functionAppHostName}/runtime/webhooks/eventgrid?functionName=ProcessVideo&code={systemKey}`
+  - System key: obtained via
+    `listKeys('${functionAppId}/host/default', '2024-04-01').systemKeys.eventgrid_extension`
+  - Retry policy: `maxDeliveryAttempts` = 30,
+    `eventTimeToLiveInMinutes` = 1440
+  - Dead-letter: blob container `status-videos`, prefix `deadletter/`
+
+Parameters: `name` (string), `location` (string), `tags` (object),
+`storageAccountId` (string), `storageAccountName` (string),
+`functionAppId` (string), `functionAppHostName` (string),
+`enableEventGrid` (bool, default: false).
+
+All resources conditionally deployed: `if (enableEventGrid)`.
+
+See contracts/event-grid-trigger.md for subscription configuration and
+R-003 for deployment ordering rationale (Event Grid must be in its own
+module to avoid circular dependencies with storage.bicep).
+
+### T003 Details
+
+Modify `infra/modules/key-vault.bicep` to add two new secrets:
+
+- `CloudflareApiToken`: Cloudflare API token with Stream Write
+  permission (parameter with `@secure()` decorator)
+- `CloudflareAccountId`: Cloudflare account identifier
+
+Grant the Function App managed identity `Key Vault Secrets User` role
+for these secrets (if not already granted at the vault level).
+
+### T004 Details
+
+Modify `infra/modules/function-app.bicep` to add application settings
+that reference Key Vault secrets:
+
+- `CLOUDFLARE_ACCOUNT_ID`:
+  `@Microsoft.KeyVault(VaultName={vaultName};SecretName=CloudflareAccountId)`
+- `CLOUDFLARE_API_TOKEN`:
+  `@Microsoft.KeyVault(VaultName={vaultName};SecretName=CloudflareApiToken)`
+
+Add a new parameter `keyVaultName` (string) to receive the Key Vault
+name from the orchestrator.
+
+See quickstart.md section 1 for local development equivalents in
+`local.settings.json`.
+
+### T005 Details
+
+Remove the commented-out Event Grid system topic and event subscription
+resources from `infra/modules/storage.bicep`. These resources have been
+extracted into the dedicated `infra/modules/event-grid.bicep` module
+(T002) to resolve the deployment ordering issue described in R-003.
+
+No new resources are added to this file — just cleanup.
+
+### T006 Details
+
+Modify `infra/main.bicep`:
+
+1. Add parameter: `enableEventGrid` (bool, default: false) with
+   description explaining the two-pass bootstrap requirement
+2. Add the `event-grid` module reference:
+   - Depends on: `storage` module and `functionApp` module
+   - Pass required parameters: storage account ID/name, Function App
+     ID/hostname, enableEventGrid flag
+3. Update module dependency order:
+   ```
+   monitoring → (no deps)
+   storage → (no deps)
+   functionApp → storage, monitoring
+   eventGrid → storage, functionApp      ← NEW
+   keyVault → functionApp
+   apim → functionApp
+   ```
+4. Pass `keyVaultName` output from keyVault module to functionApp
+   module for Key Vault reference app settings (T004)
+
+See R-003 for the two-pass bootstrap strategy and quickstart.md
+section 6 for deployment commands.
+
+**Checkpoint**: Infrastructure is ready. All Bicep modules can be
+deployed (with `enableEventGrid=false` for first deployment). Proceed
+to user story implementation.
+
+---
+
+## Phase 3: US-4 — Enable Event Grid Infrastructure (P1)
+
+**Goal**: Deploy Event Grid system topic and event subscription so that
+blob upload events are reliably delivered to the processing function
+endpoint.
+
+**Independent Test**: Deploy updated infrastructure, upload a blob to
+`status-videos/uploads/`, verify the Event Grid event is delivered to
+the function endpoint. Deployment completes without errors in all
+environments.
+
+### Implementation for US-4
+
+- [ ] T007 [US4] Execute two-pass bootstrap deployment for Event Grid infrastructure
+
+### T007 Details
+
+Deploy the infrastructure using the two-pass bootstrap strategy from
+R-003 and quickstart.md section 6:
+
+1. **First pass** — deploy with `enableEventGrid=false`:
+   ```bash
+   azd provision
+   ```
+   This deploys all resources except the Event Grid subscription. The
+   Function App must exist and have code deployed before the Event Grid
+   subscription can be created (webhook validation handshake).
+
+2. **Deploy function code**:
+   ```bash
+   azd deploy
+   ```
+   The Functions runtime starts, loads the EventGrid extension, and
+   creates the `eventgrid_extension` system key.
+
+3. **Second pass** — deploy with `enableEventGrid=true`:
+   ```bash
+   azd provision --parameter enableEventGrid=true
+   ```
+   The Event Grid subscription is created with a valid webhook URL
+   containing the system key. The webhook validation handshake succeeds
+   because the Function App is running.
+
+Verify (FR-012, FR-013, FR-014, FR-015, FR-016, SC-007):
+
+- Event Grid system topic exists on the storage account
+- Event subscription filters to `uploads/` prefix in `status-videos`
+- Webhook endpoint URL is valid and reachable
+- Retry policy: 30 attempts, 1440 min TTL
+- Dead-letter destination: `status-videos/deadletter/`
+- Deployment completed without errors
+
+**Checkpoint**: Event Grid infrastructure is live. BlobCreated events
+in the `uploads/` path will be delivered to the ProcessVideo function
+endpoint.
+
+---
+
+## Phase 4: US-1 — Automatically Transcode Uploaded Video (P1) 🎯 MVP
+
+**Goal**: When a video blob is created in `status-videos/uploads/`, the
+system detects the event, generates a read SAS URL, and submits it to
+Cloudflare Stream for transcoding.
+
+**Independent Test**: Upload a video to the `status-videos/uploads/`
+path, verify the Event Grid trigger fires, a read SAS URL is generated,
+and the video is submitted to Cloudflare Stream. Cloudflare returns a
+video UID and begins processing.
+
+### Tests for US-1 ⚠️
+
+> **NOTE: Write these tests FIRST. Create minimal model/interface stubs
+> to allow compilation, then write test cases. Tests should FAIL until
+> ProcessVideo is implemented in T015.**
+
+- [ ] T008 [US1] Write unit tests for ProcessVideo function in `api/Api.Tests/Functions/ProcessVideoTests.cs`
+
+### Implementation for US-1
+
+- [ ] T009 [P] [US1] Create CloudflareStreamRequest model in `api/Models/CloudflareStreamRequest.cs`
+- [ ] T010 [P] [US1] Create CloudflareStreamResponse models in `api/Models/CloudflareStreamResponse.cs`
+- [ ] T011 [P] [US1] Extend ISasUrlService with read SAS method in `api/Services/ISasUrlService.cs`
+- [ ] T012 [US1] Create ICloudflareStreamService interface in `api/Services/ICloudflareStreamService.cs`
+- [ ] T013 [P] [US1] Implement read SAS URL generation in `api/Services/SasUrlService.cs`
+- [ ] T014 [US1] Implement CloudflareStreamService in `api/Services/CloudflareStreamService.cs`
+- [ ] T015 [US1] Create ProcessVideo Event Grid trigger function in `api/Functions/ProcessVideo.cs`
+- [ ] T016 [US1] Register services and configure HttpClient in `api/Program.cs`
+
+### T008 Details
+
+Write xUnit tests for the ProcessVideo function BEFORE implementation
+(TDD). Mock `ISasUrlService` and `ICloudflareStreamService` using Moq.
+
+As a first step, create minimal interface and model stubs so the test
+file compiles:
+
+- `ICloudflareStreamService` with `SubmitForTranscodingAsync` signature
+- `CloudflareStreamResponse` and `CloudflareStreamRequest` as empty records
+- `ISasUrlService.GenerateReadSasUrlAsync` method signature
+
+Then write these test cases (all should fail — RED):
+
+- **Valid video**: BlobCreated event with `video/mp4` content type and
+  valid size → generates read SAS URL → submits to Cloudflare → succeeds
+- **Valid QuickTime video**: Event with `video/quicktime` → processes
+  normally
+- **Unsupported content type**: Event with `text/plain` or `image/png`
+  → acknowledged without submission, logs skip
+- **Zero-size blob**: Event with `contentLength` = 0 → acknowledged
+  without submission
+- **Oversized blob**: Event with `contentLength` > 52,428,800 (50 MB)
+  → acknowledged without submission
+- **Wrong path prefix**: Blob URL not under `uploads/` → acknowledged
+  without submission
+- **Duplicate event (idempotency)**: Same eTag delivered twice → second
+  event does not trigger duplicate Cloudflare submission
+- **SAS URL generation**: Verify `GenerateReadSasUrlAsync` is called
+  with correct blob path
+- **Cloudflare submission**: Verify `SubmitForTranscodingAsync` is called
+  with the generated SAS URL
+- **Transient failure**: Cloudflare service throws → exception propagates
+  (triggers Event Grid retry)
+- **Permanent failure**: Cloudflare service indicates 400 → acknowledged,
+  no exception thrown
+
+Mock `EventGridEvent` with `Data` containing serialized
+`StorageBlobCreatedEventData` JSON. See R-001 for event schema.
+
+### T009 Details
+
+Create `api/Models/CloudflareStreamRequest.cs` with JSON serialization:
+
+```csharp
+public record CloudflareStreamRequest(
+    [property: JsonPropertyName("url")] string Url,
+    [property: JsonPropertyName("meta")] Dictionary<string, string>? Meta = null,
+    [property: JsonPropertyName("requireSignedURLs")] bool? RequireSignedURLs = null
+);
+```
+
+See data-model.md `CloudflareStreamRequest` entity for field definitions.
+
+### T010 Details
+
+Create `api/Models/CloudflareStreamResponse.cs` with all Cloudflare v4
+API envelope types as records:
+
+- `CloudflareStreamResponse` — top-level: `Success` (bool), `Result`
+  (`CloudflareStreamResult?`), `Errors` (`List<CloudflareError>`),
+  `Messages` (`List<CloudflareMessage>`)
+- `CloudflareStreamResult` — `Uid` (string), `ReadyToStream` (bool),
+  `Status` (`CloudflareStatus`), `Playback` (`CloudflarePlayback?`)
+- `CloudflareStatus` — `State` (string), `PctComplete` (string?),
+  `ErrorReasonCode` (string?), `ErrorReasonText` (string?)
+- `CloudflarePlayback` — `Hls` (string?), `Dash` (string?)
+- `CloudflareError` — `Code` (int), `Message` (string)
+- `CloudflareMessage` — `Code` (int), `Message` (string)
+
+All properties should use `[JsonPropertyName]` attributes for camelCase
+JSON mapping.
+
+See data-model.md for complete field definitions and
+contracts/cloudflare-stream-api.md for response examples.
+
+### T011 Details
+
+Extend the existing `ISasUrlService` interface with a new method:
+
+```csharp
+Task<SasUrlResult> GenerateReadSasUrlAsync(
+    string blobPath,
+    CancellationToken cancellationToken = default);
+```
+
+This method generates a read-only SAS URL for an existing blob. The
+existing `GenerateSasUrlAsync` method (write+create) remains unchanged.
+
+See R-004 in research.md for design rationale.
+
+### T012 Details
+
+Create `api/Services/ICloudflareStreamService.cs`:
+
+```csharp
+public interface ICloudflareStreamService
+{
+    Task<CloudflareStreamResponse> SubmitForTranscodingAsync(
+        Uri videoReadUrl,
+        string blobPath,
+        CancellationToken cancellationToken = default);
+}
+```
+
+The method accepts the read SAS URL and blob path (for metadata tracing),
+returns the Cloudflare response with the video UID.
+
+Depends on T009 and T010 (model types used in the interface signature).
+
+### T013 Details
+
+Implement `GenerateReadSasUrlAsync` in `api/Services/SasUrlService.cs`:
+
+- Follow the same user delegation key pattern as the existing
+  `GenerateSasUrlAsync` method
+- Use `BlobSasPermissions.Read` (not Write+Create)
+- Set expiry to 60 minutes (per FR-003)
+- Scope to the specific blob path
+- Protocol: `SasProtocol.Https` only
+- Return `SasUrlResult` with the generated URI and expiration timestamp
+
+See R-004 in research.md for implementation approach. The existing
+`BlobServiceClient` registration is reused — no additional DI changes.
+
+### T014 Details
+
+Implement `api/Services/CloudflareStreamService.cs`:
+
+- Accept `HttpClient` via constructor (typed HttpClient pattern for DI)
+- Read `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` from
+  `IConfiguration`
+- `SubmitForTranscodingAsync` implementation:
+  1. Build `CloudflareStreamRequest` with the SAS URL and metadata
+     (`blobPath` in `meta` dictionary)
+  2. Set `Authorization: Bearer {apiToken}` header
+  3. POST to `accounts/{account_id}/stream/copy`
+  4. Deserialize response as `CloudflareStreamResponse`
+  5. On success (`response.Success == true`): return response
+  6. On HTTP 429 (rate limit): throw to trigger Event Grid retry
+  7. On HTTP 5xx: throw to trigger Event Grid retry
+  8. On HTTP 400/401: throw specific exception indicating permanent
+     failure (caller decides whether to acknowledge or rethrow)
+
+See contracts/cloudflare-stream-api.md for request/response schemas
+and error codes (10000, 10001, 10004, 10005).
+See R-002 for rate limit details (120 concurrent, ~1200 req/5 min).
+
+### T015 Details
+
+Create `api/Functions/ProcessVideo.cs` — Event Grid triggered function:
+
+```csharp
+[Function(nameof(ProcessVideo))]
+public async Task Run(
+    [EventGridTrigger] EventGridEvent eventGridEvent)
+```
+
+Constructor DI: `ILogger<ProcessVideo>`, `ISasUrlService`,
+`ICloudflareStreamService`.
+
+Implementation flow (see contracts/event-grid-trigger.md and
+data-model.md event flow diagram):
+
+1. Deserialize event data:
+   `eventGridEvent.Data.ToObjectFromJson<StorageBlobCreatedEventData>()`
+   (R-001)
+2. Parse blob path from `blobData.Url` — extract relative path after
+   the container name
+3. **Validate path prefix**: Must start with `uploads/` (FR-013). If
+   not, log and return (acknowledge).
+4. **Validate content type**: Must be `video/mp4` or `video/quicktime`
+   (FR-010). If not, log skip and return.
+5. **Validate size**: `contentLength > 0` and
+   `contentLength <= 52_428_800` (50 MB). If invalid, log and return.
+6. **Idempotency check**: Use `blobData.ETag` to detect duplicate
+   events (FR-008). Log and return if already processed.
+7. **Generate read SAS URL**: Call
+   `ISasUrlService.GenerateReadSasUrlAsync(blobPath)` (FR-002, FR-003)
+8. **Submit to Cloudflare**: Call
+   `ICloudflareStreamService.SubmitForTranscodingAsync(sasUrl, blobPath)`
+   (FR-004, FR-005)
+9. **Log success**: Log blob path and Cloudflare video UID
+   (FR-009, FR-011)
+10. **Error handling**: Transient errors throw to trigger Event Grid
+    retry (FR-007). Permanent errors log and return.
+
+This task should make all T008 tests pass (GREEN).
+
+### T016 Details
+
+Modify `api/Program.cs` to register new services:
+
+1. Register `ICloudflareStreamService` / `CloudflareStreamService`
+   with a typed `HttpClient`:
+   ```csharp
+   builder.Services
+       .AddHttpClient<ICloudflareStreamService, CloudflareStreamService>(
+           client =>
+           {
+               client.BaseAddress = new Uri(
+                   "https://api.cloudflare.com/client/v4/");
+           });
+   ```
+2. Verify `ISasUrlService` / `SasUrlService` registration already
+   exists (from Feature 002). No changes needed if already registered.
+
+**Checkpoint**: US-1 is fully functional. Uploading a video to
+`status-videos/uploads/` triggers the Event Grid function, generates
+a read SAS URL, and submits it to Cloudflare Stream. All unit tests
+pass.
+
+---
+
+## Phase 5: US-2 — Recover from Transcoding Submission Failure (P1)
+
+**Goal**: Transient failures submitting to Cloudflare Stream are
+automatically retried via Event Grid retry policy. Permanent failures
+are logged and acknowledged. Events exhausting all retries are
+dead-lettered.
+
+**Independent Test**: Simulate a transient Cloudflare failure (5xx),
+verify the function throws an exception, Event Grid retries delivery,
+and the video is eventually submitted. Simulate permanent failure,
+verify the event is acknowledged and logged without retry. Verify
+dead-letter delivery after max retries.
+
+### Tests for US-2 ⚠️
+
+- [ ] T017 [US2] Write failure and retry behavior tests in `api/Api.Tests/Functions/ProcessVideoTests.cs`
+
+### Implementation for US-2
+
+- [ ] T018 [US2] Implement error classification in `api/Functions/ProcessVideo.cs`
+
+### T017 Details
+
+Add test cases to `ProcessVideoTests.cs` for failure recovery scenarios:
+
+- **Transient 503**: Cloudflare returns HTTP 503 → function throws
+  exception (Event Grid will retry)
+- **Transient 429**: Cloudflare returns HTTP 429 (rate limit) →
+  function throws exception
+- **Transient timeout**: HttpClient throws `TaskCanceledException` →
+  function throws (not swallowed)
+- **Network failure**: `HttpRequestException` → function throws
+- **Permanent 400**: Cloudflare returns 400 (bad request) → function
+  logs error and returns normally (acknowledged, no retry)
+- **Permanent 401**: Cloudflare returns 401 (invalid auth) → function
+  logs error and returns normally
+- **SAS URL generation failure**: `ISasUrlService` throws → function
+  throws (triggers retry — storage may be transiently unavailable)
+- **Comprehensive logging**: Verify failure logs include blob path,
+  content type, content length, error details, and failure classification
+  (FR-009, SC-006)
+
+### T018 Details
+
+Refine error handling in `ProcessVideo.cs` to classify errors:
+
+**Transient (throw → Event Grid retries)**:
+
+- HTTP 429 (rate limit exceeded)
+- HTTP 5xx (server error)
+- `HttpRequestException` (network failure)
+- `TaskCanceledException` (timeout)
+- SAS URL generation failures
+
+**Permanent (acknowledge → no retry)**:
+
+- HTTP 400 with Cloudflare error code 10005 (validation)
+- HTTP 401 with Cloudflare error code 10000 (authentication — requires
+  operator intervention, not retry)
+- Content type validation failure
+- Size validation failure
+
+Log all failures with: blob path, content type, content length,
+error details, and classification (transient vs. permanent).
+
+If T015 already includes basic error handling, this task refines the
+classification and ensures comprehensive structured logging for all
+failure paths.
+
+**Checkpoint**: US-2 is complete. Transient Cloudflare failures trigger
+Event Grid retries (30 attempts, 1440 min TTL). Permanent failures are
+acknowledged and logged. Dead-lettering is configured in the Event Grid
+subscription (Phase 2, T002).
+
+---
+
+## Phase 6: US-3 — Track Video Processing Status (P2)
+
+**Goal**: After successful submission to Cloudflare Stream, the system
+records the video UID and logs structured information for processing
+status tracking by downstream features.
+
+**Independent Test**: Submit a video for transcoding, verify the
+Cloudflare video UID is logged and associated with the blob path.
+Verify structured logs contain blob path, content type, size, and
+video UID and are queryable in Application Insights.
+
+### Implementation for US-3
+
+- [ ] T019 [US3] Implement structured logging for processing status in `api/Functions/ProcessVideo.cs`
+- [ ] T020 [US3] Record Cloudflare video UID on successful submission in `api/Functions/ProcessVideo.cs`
+
+### T019 Details
+
+Enhance structured logging in `ProcessVideo.cs` using
+`ILogger<ProcessVideo>`:
+
+Log on each processing stage:
+
+1. **Event received**: Log blob path, content type, content length, eTag
+2. **Validation skipped**: Log reason (unsupported content type, invalid
+   size, wrong path prefix, duplicate event)
+3. **SAS URL generated**: Log blob path, SAS expiry timestamp
+4. **Submission success**: Log blob path, Cloudflare video UID, initial
+   processing state
+5. **Submission failure**: Log blob path, HTTP status code, Cloudflare
+   error code/message, failure classification
+
+Use structured log templates with named parameters for Application
+Insights queryability:
+
+```csharp
+_logger.LogInformation(
+    "Video submitted for transcoding. BlobPath={BlobPath}, "
+    + "VideoUid={VideoUid}, State={State}",
+    blobPath, response.Result?.Uid, response.Result?.Status?.State);
+```
+
+Satisfies FR-009 and SC-006.
+
+### T020 Details
+
+After a successful Cloudflare Stream submission in `ProcessVideo.cs`:
+
+1. Extract `result.uid` from the `CloudflareStreamResponse`
+2. Log the association: blob path → video UID (FR-011)
+3. The video UID is the identifier that downstream features will use
+   to check transcoding status and retrieve playback URLs
+
+**Note**: Persistent storage of the blob-path-to-UID mapping is out of
+scope for this feature (no database exists yet). The video UID is
+captured in structured logs and can be queried via Application Insights.
+A future feature may introduce a database for this mapping.
+
+**Checkpoint**: US-3 is complete. All processing events are logged with
+structured data. Video UIDs are recorded and queryable.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+> Final validation, documentation, and cleanup.
+
+- [ ] T021 [P] Run quickstart.md local validation (build, curl test, dotnet test)
+- [ ] T022 [P] Verify all 16 functional requirements are addressed
+- [ ] T023 Update local.settings.json with Cloudflare development credentials in `api/local.settings.json`
+
+### T021 Details
+
+Follow quickstart.md to validate the complete implementation locally:
+
+1. Add Cloudflare credentials to `local.settings.json` (section 1)
+2. Build and run the function app:
+   `cd api && dotnet build && func start` (section 2)
+3. Send test curl request with BlobCreated event JSON (section 3)
+4. Verify unsupported content type is rejected (section 4)
+5. Run all unit tests:
+   `cd api/Api.Tests && dotnet test` (section 5)
+
+All tests should pass. The local function should process the test event
+and log the expected output.
+
+### T022 Details
+
+Cross-reference all 16 functional requirements against implemented tasks:
+
+| FR | Description | Covered By |
+|----|-------------|------------|
+| FR-001 | Detect BlobCreated events | T002, T015 |
+| FR-002 | Generate time-limited read URL | T011, T013 |
+| FR-003 | Read URL ~1 hour expiry | T013 |
+| FR-004 | Submit to transcoding service | T014, T015 |
+| FR-005 | Include auth credentials | T003, T004, T014 |
+| FR-006 | Secure credential storage (Key Vault) | T003 |
+| FR-007 | Auto-retry transient failures | T002, T018 |
+| FR-008 | Idempotent duplicate handling | T015 |
+| FR-009 | Structured logging | T019 |
+| FR-010 | Validate content type | T015 |
+| FR-011 | Record transcoding job ID | T020 |
+| FR-012 | Deploy Event Grid system topic | T002 |
+| FR-013 | Filter to uploads/ path | T002, T015 |
+| FR-014 | Deliver to function endpoint | T002 |
+| FR-015 | Retry policy + dead-letter | T002 |
+| FR-016 | Deployment succeeds | T007 |
+
+All FRs must have at least one covering task. Flag any gaps.
+
+### T023 Details
+
+Update `api/local.settings.json` to include Cloudflare development
+credentials:
+
+```json
+{
+  "Values": {
+    "CLOUDFLARE_ACCOUNT_ID": "<your-account-id>",
+    "CLOUDFLARE_API_TOKEN": "<your-api-token>"
+  }
+}
+```
+
+These are local development values only. Production values are stored
+in Key Vault (T003).
+
+Ensure `local.settings.json` remains in `.gitignore` to prevent
+credential leakage.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US-4 (Phase 3)**: Depends on Phase 2 — infrastructure deployment validation
+- **US-1 (Phase 4)**: Depends on Phase 2 — can start in parallel with
+  Phase 3 (code development does not require deployed infrastructure)
+- **US-2 (Phase 5)**: Depends on Phase 4 — extends ProcessVideo error
+  handling
+- **US-3 (Phase 6)**: Depends on Phase 4 — extends ProcessVideo logging
+- **Polish (Phase 7)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US-4 (P1)**: Can start after Foundational — no code dependencies
+- **US-1 (P1) 🎯 MVP**: Can start after Foundational — core pipeline,
+  no dependencies on US-4 deployment (develop and test locally)
+- **US-2 (P1)**: Extends US-1 error handling — depends on US-1
+- **US-3 (P2)**: Extends US-1 logging — depends on US-1
+- **US-2 and US-3**: Can run in parallel with each other once US-1
+  is complete (they modify different concerns in ProcessVideo.cs)
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation (TDD)
+- Models before service interfaces
+- Service interfaces before implementations
+- Services before function
+- Function before Program.cs registration
+
+### Parallel Opportunities
+
+- **Phase 2**: T002, T003, T004, T005 can all run in parallel (different
+  Bicep files, no interdependency). T006 depends on all of them.
+- **Phase 4**: T009, T010, T011 can run in parallel (different files)
+- **Phase 4**: T013 can run in parallel with T012 (different services)
+- **Phase 5 + Phase 6**: US-2 and US-3 can run in parallel after US-1
+- **Phase 7**: T021 and T022 can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all independent models and interface extensions together:
+Task: "Create CloudflareStreamRequest model in api/Models/CloudflareStreamRequest.cs"
+Task: "Create CloudflareStreamResponse models in api/Models/CloudflareStreamResponse.cs"
+Task: "Extend ISasUrlService with read SAS method in api/Services/ISasUrlService.cs"
+
+# After models are ready, service work can proceed:
+Task: "Implement read SAS in api/Services/SasUrlService.cs"
+Task: "Create ICloudflareStreamService interface in api/Services/ICloudflareStreamService.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US-4 + US-1)
+
+1. Complete Phase 1: Setup (add EventGrid package)
+2. Complete Phase 2: Foundational (all infrastructure Bicep)
+3. Complete Phase 3: US-4 (deploy and validate Event Grid)
+4. Complete Phase 4: US-1 (core pipeline — models, services, function)
+5. **STOP and VALIDATE**: Test US-1 with local curl and unit tests
+6. Deploy and verify video transcoding works end-to-end
+
+### Incremental Delivery
+
+1. Setup + Foundational → Infrastructure ready
+2. US-4 (deploy) → Events flowing
+3. US-1 (core) → Videos transcoded (MVP!)
+4. US-2 (retry) → Failures recover automatically
+5. US-3 (tracking) → Processing status logged
+6. Each story adds reliability and observability without breaking
+   previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: US-4 (deployment) + US-1 (core pipeline)
+   - Developer B: Review infrastructure, prepare test scenarios
+3. After US-1 is complete:
+   - Developer A: US-2 (failure recovery)
+   - Developer B: US-3 (status tracking)
+4. Both stories complete independently and integrate cleanly
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps tasks to specific user story for traceability
+- Each user story should be independently testable at its checkpoint
+- TDD: Write tests FIRST, ensure they FAIL, then implement
+- Commit after each task using conventional commits
+- Two-pass deployment (`enableEventGrid`): Required for Event Grid
+  webhook validation handshake (R-003)
+- Idempotency via eTag: Simple in-memory or log-based approach without
+  external state store (Constitution VII — Simplicity)
+- Local testing: POST to
+  `/runtime/webhooks/EventGrid?functionName=ProcessVideo` with
+  `aeg-event-type: Notification` header (R-001)

--- a/specs/003-stream-video-transcoding/tasks.md
+++ b/specs/003-stream-video-transcoding/tasks.md
@@ -14,7 +14,7 @@
 
 > Add the Event Grid trigger extension package to the Azure Functions project.
 
-- [ ] T001 Add EventGrid trigger package to `api/Api.csproj`
+- [x] T001 Add EventGrid trigger package to `api/Api.csproj`
 
 ### T001 Details
 
@@ -32,11 +32,11 @@ See R-001 in research.md for package selection rationale.
 > operate: Event Grid event delivery, Cloudflare credential storage, and
 > application configuration. All user stories depend on this phase.
 
-- [ ] T002 [P] Create Event Grid Bicep module in `infra/modules/event-grid.bicep`
-- [ ] T003 [P] Modify Key Vault module to add Cloudflare secrets in `infra/modules/key-vault.bicep`
-- [ ] T004 [P] Modify Function App module to add Cloudflare app settings in `infra/modules/function-app.bicep`
-- [ ] T005 [P] Remove commented-out Event Grid resources from `infra/modules/storage.bicep`
-- [ ] T006 Wire Event Grid module and enableEventGrid parameter in `infra/main.bicep`
+- [x] T002 [P] Create Event Grid Bicep module in `infra/modules/event-grid.bicep`
+- [x] T003 [P] Modify Key Vault module to add Cloudflare secrets in `infra/modules/key-vault.bicep`
+- [x] T004 [P] Modify Function App module to add Cloudflare app settings in `infra/modules/function-app.bicep`
+- [x] T005 [P] Remove commented-out Event Grid resources from `infra/modules/storage.bicep`
+- [x] T006 Wire Event Grid module and enableEventGrid parameter in `infra/main.bicep`
 
 ### T002 Details
 
@@ -149,7 +149,7 @@ environments.
 
 ### Implementation for US-4
 
-- [ ] T007 [US4] Execute two-pass bootstrap deployment for Event Grid infrastructure
+- [x] T007 [US4] Execute two-pass bootstrap deployment for Event Grid infrastructure
 
 ### T007 Details
 
@@ -211,18 +211,18 @@ video UID and begins processing.
 > to allow compilation, then write test cases. Tests should FAIL until
 > ProcessVideo is implemented in T015.**
 
-- [ ] T008 [US1] Write unit tests for ProcessVideo function in `api/Api.Tests/Functions/ProcessVideoTests.cs`
+- [x] T008 [US1] Write unit tests for ProcessVideo function in `api/Api.Tests/Functions/ProcessVideoTests.cs`
 
 ### Implementation for US-1
 
-- [ ] T009 [P] [US1] Create CloudflareStreamRequest model in `api/Models/CloudflareStreamRequest.cs`
-- [ ] T010 [P] [US1] Create CloudflareStreamResponse models in `api/Models/CloudflareStreamResponse.cs`
-- [ ] T011 [P] [US1] Extend ISasUrlService with read SAS method in `api/Services/ISasUrlService.cs`
-- [ ] T012 [US1] Create ICloudflareStreamService interface in `api/Services/ICloudflareStreamService.cs`
-- [ ] T013 [P] [US1] Implement read SAS URL generation in `api/Services/SasUrlService.cs`
-- [ ] T014 [US1] Implement CloudflareStreamService in `api/Services/CloudflareStreamService.cs`
-- [ ] T015 [US1] Create ProcessVideo Event Grid trigger function in `api/Functions/ProcessVideo.cs`
-- [ ] T016 [US1] Register services and configure HttpClient in `api/Program.cs`
+- [x] T009 [P] [US1] Create CloudflareStreamRequest model in `api/Models/CloudflareStreamRequest.cs`
+- [x] T010 [P] [US1] Create CloudflareStreamResponse models in `api/Models/CloudflareStreamResponse.cs`
+- [x] T011 [P] [US1] Extend ISasUrlService with read SAS method in `api/Services/ISasUrlService.cs`
+- [x] T012 [US1] Create ICloudflareStreamService interface in `api/Services/ICloudflareStreamService.cs`
+- [x] T013 [P] [US1] Implement read SAS URL generation in `api/Services/SasUrlService.cs`
+- [x] T014 [US1] Implement CloudflareStreamService in `api/Services/CloudflareStreamService.cs`
+- [x] T015 [US1] Create ProcessVideo Event Grid trigger function in `api/Functions/ProcessVideo.cs`
+- [x] T016 [US1] Register services and configure HttpClient in `api/Program.cs`
 
 ### T008 Details
 
@@ -453,11 +453,11 @@ dead-letter delivery after max retries.
 
 ### Tests for US-2 ⚠️
 
-- [ ] T017 [US2] Write failure and retry behavior tests in `api/Api.Tests/Functions/ProcessVideoTests.cs`
+- [x] T017 [US2] Write failure and retry behavior tests in `api/Api.Tests/Functions/ProcessVideoTests.cs`
 
 ### Implementation for US-2
 
-- [ ] T018 [US2] Implement error classification in `api/Functions/ProcessVideo.cs`
+- [x] T018 [US2] Implement error classification in `api/Functions/ProcessVideo.cs`
 
 ### T017 Details
 
@@ -527,8 +527,8 @@ video UID and are queryable in Application Insights.
 
 ### Implementation for US-3
 
-- [ ] T019 [US3] Implement structured logging for processing status in `api/Functions/ProcessVideo.cs`
-- [ ] T020 [US3] Record Cloudflare video UID on successful submission in `api/Functions/ProcessVideo.cs`
+- [x] T019 [US3] Implement structured logging for processing status in `api/Functions/ProcessVideo.cs`
+- [x] T020 [US3] Record Cloudflare video UID on successful submission in `api/Functions/ProcessVideo.cs`
 
 ### T019 Details
 
@@ -581,9 +581,9 @@ structured data. Video UIDs are recorded and queryable.
 
 > Final validation, documentation, and cleanup.
 
-- [ ] T021 [P] Run quickstart.md local validation (build, curl test, dotnet test)
-- [ ] T022 [P] Verify all 16 functional requirements are addressed
-- [ ] T023 Update local.settings.json with Cloudflare development credentials in `api/local.settings.json`
+- [x] T021 [P] Run quickstart.md local validation (build, curl test, dotnet test)
+- [x] T022 [P] Verify all 16 functional requirements are addressed
+- [x] T023 Update local.settings.json with Cloudflare development credentials in `api/local.settings.json`
 
 ### T021 Details
 


### PR DESCRIPTION
I created the `ProcessVideo` Azure Function that subscribes to Event Grid events when videos are uploaded to the Azure Storage Blob container. `ProcessVideo` will create a read SAS URL for the video and will send that URL to the Cloudflare Stream API to download the video, transcode it, and make it available for on-demand streaming playback.

Closes #9